### PR TITLE
Speed up smart search: both fine and coarse grid

### DIFF
--- a/ADSE13_25/indexing/iota_strategies.py
+++ b/ADSE13_25/indexing/iota_strategies.py
@@ -167,23 +167,25 @@ class RealSpaceGridSmartSearch(Strategy):
     import time
     time1=time.time()
     if find_max_within_cluster:
-      top_n_values=1 # number of top scoring vectors to return in each coarse grid per unique dimension
-      for count in range(len(SST.n_entries_finegrained[:-1])):
-        start=SST.n_entries_finegrained[count]
-        end=SST.n_entries_finegrained[count+1]
-        for l in unique_cell_dimensions:
-          tmp_vectors = flex.vec3_double()
-          tmp_function_values = flex.double()
-          for i, direction in enumerate(SST.finegrained_angles[start:end]):
-            v = matrix.col(direction.dvec) * l
-            f = compute_functional(v.elems, reciprocal_lattice_vectors)
-            tmp_vectors.append(v.elems)
-            tmp_function_values.append(f)
-          perm=flex.sort_permutation(tmp_function_values, reverse=True)
-          tmp_vectors=tmp_vectors.select(perm)[0:top_n_values]
-          tmp_function_values=tmp_function_values.select(perm)[0:top_n_values]
-          vectors.extend(tmp_vectors)
-          function_values.extend(tmp_function_values)
+      # C++ version
+      vectors, function_values = SST.fine_grid_search_cpp(SST.finegrained_angles, flex.double(list(unique_cell_dimensions)), reciprocal_lattice_vectors )
+      #top_n_values=1 # number of top scoring vectors to return in each coarse grid per unique dimension
+      #for count in range(len(SST.n_entries_finegrained[:-1])):
+      #  start=SST.n_entries_finegrained[count]
+      #  end=SST.n_entries_finegrained[count+1]
+      #  for l in unique_cell_dimensions:
+      #    tmp_vectors = flex.vec3_double()
+      #    tmp_function_values = flex.double()
+      #    for i, direction in enumerate(SST.finegrained_angles[start:end]):
+      #      v = matrix.col(direction.dvec) * l
+      #      f = compute_functional(v.elems, reciprocal_lattice_vectors)
+      #      tmp_vectors.append(v.elems)
+      #      tmp_function_values.append(f)
+      #    perm=flex.sort_permutation(tmp_function_values, reverse=True)
+      #    tmp_vectors=tmp_vectors.select(perm)[0:top_n_values]
+      #    tmp_function_values=tmp_function_values.select(perm)[0:top_n_values]
+      #    vectors.extend(tmp_vectors)
+      #    function_values.extend(tmp_function_values)
 
     else:
       for i, direction in enumerate(SST.finegrained_angles):


### PR DESCRIPTION
Moving compute intensive calculations of fine and coarse grid to C++.  The C++ code is in rstbx and further optimization will be done there. 
Some timings on representative LS49 image (timestamp 20180501143628702)
For generating timings, see LS49_regression/speedup_smart_search 
Coarse grid on master--> 82 seconds on KNL
Coarse grid on this branch --> 0.72 seconds on KNL 
Fine grid has similar timings as coarse grids in both branches
