### PR TITLE
Psii ground truth

### DIFF
--- a/kpp_utils/LY99_batch.py
+++ b/kpp_utils/LY99_batch.py
@@ -26,6 +26,9 @@ from simtbx import get_exascale
 
 from exafel_project.kpp_utils.phil import parse_input
 from exafel_project.kpp_utils.ferredoxin import basic_detector_rayonix
+from exafel_project.kpp_utils.amplitudes_spread_ferredoxin import ferredoxin
+from exafel_project.kpp_utils.psii_utils import psii_amplitudes_spread
+
 
 def tst_one(image,spectra,crystal,random_orientation,sfall_channels,gpu_channels_singleton,rank,params,**kwargs):
   iterator = spectra.generate_recast_renormalized_image(image=image%100000,energy=params.beam.mean_wavelength,
@@ -73,8 +76,8 @@ def run_LY99_batch(test_without_mpi=False):
   start_comp = time()
 
   # now inside the Python imports, begin energy channel calculation
-  from exafel_project.kpp_utils.amplitudes_spread_ferredoxin import ferredoxin
-  sfall_channels = ferredoxin(comm)
+  sfall_channels_d = {'ferredoxin': ferredoxin, 'PSII': psii_amplitudes_spread}
+  sfall_channels = sfall_channels_d[params.crystal.structure](comm)
   print(rank, time(), "finished with the calculation of channels, now construct single broadcast")
 
   if rank == 0:

--- a/kpp_utils/LY99_batch.py
+++ b/kpp_utils/LY99_batch.py
@@ -1,17 +1,20 @@
 from __future__ import division, print_function
+from datetime import datetime
+import io
 from time import time
+import os
+import sys
 start_elapse = time()
 
 from scitbx.matrix import sqr
-import libtbx.load_env # possibly implicit
-from cctbx import crystal
+import libtbx.load_env  # possibly implicit
 from omptbx import omp_get_num_procs
 
 # %%% boilerplate specialize to packaged big data %%%
-import os
+
 from LS49.sim import step4_pad
 from LS49.spectra import generate_spectra
-from LS49 import ls49_big_data
+from LS49 import ls49_big_data, legacy_random_orientations
 step4_pad.big_data = ls49_big_data
 generate_spectra.big_data = ls49_big_data
 from simtbx import get_exascale
@@ -34,9 +37,7 @@ def tst_one(image,spectra,crystal,random_orientation,sfall_channels,gpu_channels
   iterator = spectra.generate_recast_renormalized_image(image=image%100000,energy=params.beam.mean_wavelength,
   total_flux=params.beam.total_flux)
   quick = False
-  if quick: prefix_root="LY99_batch_%06d"
-  else: prefix_root="LY99_MPIbatch_%06d"
-
+  prefix_root = "LY99_batch_%06d" if quick else "LY99_MPIbatch_%06d"
   file_prefix = prefix_root%image
   rand_ori = sqr(random_orientation)
   from exafel_project.kpp_utils.ferredoxin import run_sim2smv
@@ -46,12 +47,11 @@ def tst_one(image,spectra,crystal,random_orientation,sfall_channels,gpu_channels
               gpu_channels_singleton=gpu_channels_singleton,
               sfall_channels=sfall_channels,params=params,**kwargs)
 
+
 def run_LY99_batch(test_without_mpi=False):
   params,options = parse_input()
   log_by_rank = bool(int(os.environ.get("LOG_BY_RANK",0)))
   rank_profile = bool(int(os.environ.get("RANK_PROFILE",1)))
-  if log_by_rank:
-    import io, sys
   if rank_profile:
     import cProfile
     pr = cProfile.Profile()
@@ -72,7 +72,6 @@ def run_LY99_batch(test_without_mpi=False):
   N_total = int(os.environ["N_SIM"]) # number of items to simulate
   N_stride = size # total number of worker tasks
   print("hello from rank %d of %d"%(rank,size),"with omp_threads=",omp_get_num_procs())
-  import datetime
   start_comp = time()
 
   # now inside the Python imports, begin energy channel calculation
@@ -81,13 +80,12 @@ def run_LY99_batch(test_without_mpi=False):
   print(rank, time(), "finished with the calculation of channels, now construct single broadcast")
 
   if rank == 0:
-    print("Rank 0 time", datetime.datetime.now())
+    print("Rank 0 time", datetime.now())
     from LS49.spectra.generate_spectra import spectra_simulation
     from LS49.sim.step4_pad import microcrystal
     print("hello2 from rank %d of %d"%(rank,size))
     SS = spectra_simulation()
     C = microcrystal(Deff_A = 4000, length_um = 4., beam_diameter_um = 1.0) # assume smaller than 10 um crystals
-    from LS49 import legacy_random_orientations
     random_orientations = legacy_random_orientations(N_total)
     transmitted_info = dict(spectra = SS,
                             crystal = C,
@@ -159,11 +157,12 @@ def run_LY99_batch(test_without_mpi=False):
   comm.barrier()
   del gpu_channels_singleton
   # avoid Kokkos allocation "device_Fhkl" being deallocated after Kokkos::finalize was called
-  print("Overall rank",rank,"at",datetime.datetime.now(),"seconds elapsed after srun startup %.3f"%(time()-start_elapse))
-  print("Overall rank",rank,"at",datetime.datetime.now(),"seconds elapsed after Python imports %.3f"%(time()-start_comp))
+  print("Overall rank",rank,"at",datetime.now(),"seconds elapsed after srun startup %.3f"%(time()-start_elapse))
+  print("Overall rank",rank,"at",datetime.now(),"seconds elapsed after Python imports %.3f"%(time()-start_comp))
   if rank_profile:
     pr.disable()
     pr.dump_stats("cpu_%d.prof"%rank)
+
 
 if __name__=="__main__":
   run_LY99_batch()

--- a/kpp_utils/phil.py
+++ b/kpp_utils/phil.py
@@ -27,6 +27,11 @@ def parse_input():
         .type = float
         .help = spectra from big data are coerced to this total flux
     }
+    crystal {
+      structure = *ferredoxin PSII
+        .type = choice
+        .help = type of crystal structure to be simulated
+    }
     detector {
       tiles = *single multipanel
         .type = choice

--- a/kpp_utils/psii_utils.py
+++ b/kpp_utils/psii_utils.py
@@ -34,7 +34,7 @@ def psii_amplitudes_spread(comm):
   size = comm.Get_size()
 
   wavelength_A = 1.89  # general ballpark X-ray wavelength in Angstroms
-  wavelengths = flex.double([ENERGY_CONV/(6520 + w) for w in range(81)])
+  wavelengths = flex.double([ENERGY_CONV/(6500 + w) for w in range(101)])
   direct_algo_res_limit = 1.85
 
   local_data = data()  # later put this through broadcast

--- a/kpp_utils/psii_utils.py
+++ b/kpp_utils/psii_utils.py
@@ -18,8 +18,8 @@ def data():
   from LS49.sim.fdp_plot import george_sherrell
   return dict(
     pdb_lines=open(full_path("7RF1_refine_030_Aa_refine_032_refine_034.pdb"), "r").read(),  # TODO? Or not?
-    Mn_oxidized_model=george_sherrell(full_path("data_sherrell/Mn_spliced4+.dat")),  # TODO
-    Mn_reduced_model=george_sherrell(full_path("data_sherrell/Mn_spliced3+.dat")),  # TODO
+    Mn_oxidized_model=george_sherrell(full_path("data_sherrell/Mn_spliced4+.dat")),  # TODO by Vidya
+    Mn_reduced_model=george_sherrell(full_path("data_sherrell/Mn_spliced3+.dat")),  # TODO by Vidya
     Mn_metallic_model=george_sherrell(full_path("data_sherrell/Mn.dat"))
   )
 

--- a/kpp_utils/psii_utils.py
+++ b/kpp_utils/psii_utils.py
@@ -1,0 +1,76 @@
+import os
+
+from dxtbx.model.experiment_list import ExperimentList
+from LS49 import ls49_big_data
+from LS49.sim.util_fmodel import gen_fmodel
+from scitbx.array_family import flex
+
+from scipy import constants
+
+ENERGY_CONV = 1e10 * constants.c * constants.h / constants.electron_volt
+
+
+def full_path(filename):
+  return os.path.join(ls49_big_data, filename)
+
+
+def data():
+  from LS49.sim.fdp_plot import george_sherrell
+  return dict(
+    pdb_lines=open(full_path("7RF1_refine_030_Aa_refine_032_refine_034.pdb"), "r").read(),  # TODO? Or not?
+    Mn_oxidized_model=george_sherrell(full_path("data_sherrell/Mn_spliced4+.dat")),  # TODO
+    Mn_reduced_model=george_sherrell(full_path("data_sherrell/Mn_spliced3+.dat")),  # TODO
+    Mn_metallic_model=george_sherrell(full_path("data_sherrell/Mn.dat"))
+  )
+
+
+def get_p20231_r0135_detector():
+  expt_path = 't000_rg002_chunk000_reintegrated_000000.expt'
+  return ExperimentList.from_file(expt_path)[0].detector
+
+
+def psii_amplitudes_spread(comm):
+  rank = comm.Get_rank()
+  size = comm.Get_size()
+
+  wavelength_A = 1.89  # general ballpark X-ray wavelength in Angstroms
+  wavelengths = flex.double([ENERGY_CONV/(6520 + w) for w in range(81)])
+  direct_algo_res_limit = 1.85
+
+  local_data = data()  # later put this through broadcast
+
+  # this is PDB 7RF1_refine_030_Aa_refine_032_refine_034
+  GF = gen_fmodel(resolution=direct_algo_res_limit,
+                  pdb_text=local_data.get("pdb_lines"),
+                  algorithm="fft", wavelength=wavelength_A)
+  GF.set_k_sol(0.435)
+  GF.make_P1_primitive()
+
+  # Generating sf for my wavelengths
+  sfall_channels = {}
+  for x in range(len(wavelengths)):
+    if rank > len(wavelengths): break
+    if x % size != rank: continue
+
+    GF.reset_wavelength(wavelengths[x])  # TODO: which to make 3+ and which 4+?
+    GF.reset_specific_at_wavelength(label_has="MN1",
+                                    tables=local_data.get("Mn_oxidized_model"),
+                                    newvalue=wavelengths[x])
+    GF.reset_specific_at_wavelength(label_has="MN2",
+                                    tables=local_data.get("Mn_oxidized_model"),
+                                    newvalue=wavelengths[x])
+    GF.reset_specific_at_wavelength(label_has="MN3",
+                                    tables=local_data.get("Mn_reduced_model"),
+                                    newvalue=wavelengths[x])
+    GF.reset_specific_at_wavelength(label_has="MN4",
+                                    tables=local_data.get("Mn_reduced_model"),
+                                    newvalue=wavelengths[x])
+    sfall_channels[x] = GF.get_amplitudes()
+
+  reports = comm.gather(sfall_channels, root=0)
+  if rank == 0:
+    sfall_channels = {}
+    for report in reports: sfall_channels.update(report)
+  comm.barrier()
+  return sfall_channels
+

--- a/kpp_utils/t000_rg002_chunk000_reintegrated_000000.expt
+++ b/kpp_utils/t000_rg002_chunk000_reintegrated_000000.expt
@@ -1,0 +1,16776 @@
+{
+  "__id__": "ExperimentList",
+  "experiment": [
+    {
+      "__id__": "Experiment",
+      "identifier": "5db310d5-05ea-4c0b-b072-ee8530bf3d80",
+      "beam": 0,
+      "detector": 0,
+      "crystal": 0,
+      "imageset": 0
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "70acde3b-162d-d122-af0b-ce75b2ea5fcf",
+      "beam": 1,
+      "detector": 0,
+      "crystal": 1,
+      "imageset": 1
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "0c6824a0-eccb-e1a4-4306-ca9264a0433d",
+      "beam": 2,
+      "detector": 0,
+      "crystal": 2,
+      "imageset": 2
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "5d0625c4-442a-4dff-85a8-a7b07d73089f",
+      "beam": 3,
+      "detector": 0,
+      "crystal": 3,
+      "imageset": 3
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "df315f0f-5ecf-f854-9ba2-b7768c00d3ec",
+      "beam": 4,
+      "detector": 0,
+      "crystal": 4,
+      "imageset": 4
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "adf7bf5e-f70d-4b6b-d967-6c1826fd2e52",
+      "beam": 5,
+      "detector": 0,
+      "crystal": 5,
+      "imageset": 5
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "c5f093e8-2136-8f05-6eaa-c44d4e5edc39",
+      "beam": 6,
+      "detector": 0,
+      "crystal": 6,
+      "imageset": 6
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "42f83f7d-eb66-735e-aaae-8d4b8623fb11",
+      "beam": 7,
+      "detector": 0,
+      "crystal": 7,
+      "imageset": 7
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "35bf8c7e-3087-7a42-3e4c-73d5b88bd8a5",
+      "beam": 8,
+      "detector": 0,
+      "crystal": 8,
+      "imageset": 8
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "7110dac9-d5ce-0679-79b0-8fa01078ffcb",
+      "beam": 9,
+      "detector": 0,
+      "crystal": 9,
+      "imageset": 9
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "00f65dbb-53e0-baba-a457-979d71e5f40f",
+      "beam": 10,
+      "detector": 0,
+      "crystal": 10,
+      "imageset": 10
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "f2d79e6d-59ea-46b6-bb13-f246c13f044e",
+      "beam": 11,
+      "detector": 0,
+      "crystal": 11,
+      "imageset": 11
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "27d5ae91-a298-f1c5-4aad-d80dde37361a",
+      "beam": 12,
+      "detector": 0,
+      "crystal": 12,
+      "imageset": 12
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "6c40943f-2f8d-de31-cd33-cc9012fe717f",
+      "beam": 13,
+      "detector": 0,
+      "crystal": 13,
+      "imageset": 13
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "3d452432-540e-2bd8-2847-0144b6c130a8",
+      "beam": 14,
+      "detector": 0,
+      "crystal": 14,
+      "imageset": 14
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "79a5e40b-beb0-9507-b29b-79d0bebbba75",
+      "beam": 15,
+      "detector": 0,
+      "crystal": 15,
+      "imageset": 15
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "b7a9ffec-5ef0-5aa4-2e33-cfa7457b1949",
+      "beam": 16,
+      "detector": 0,
+      "crystal": 16,
+      "imageset": 16
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "9ea230b3-e31b-be3c-0549-dfac93aa049d",
+      "beam": 17,
+      "detector": 0,
+      "crystal": 17,
+      "imageset": 17
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "ce755c02-315c-0e92-aeb4-ec2a5cd3edf7",
+      "beam": 18,
+      "detector": 0,
+      "crystal": 18,
+      "imageset": 18
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "3498e20f-359a-4a8f-b403-570ab3201903",
+      "beam": 19,
+      "detector": 0,
+      "crystal": 19,
+      "imageset": 19
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "99d26eff-0467-f9b6-5ec8-a435a98d8af4",
+      "beam": 20,
+      "detector": 0,
+      "crystal": 20,
+      "imageset": 20
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "c03a849c-6f3a-ec68-3f3f-c917f1d8d018",
+      "beam": 21,
+      "detector": 0,
+      "crystal": 21,
+      "imageset": 21
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "8cb8899e-5d45-c28c-4e37-abfd661d1c2c",
+      "beam": 22,
+      "detector": 0,
+      "crystal": 22,
+      "imageset": 22
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "d68e6b00-07c3-d70d-714f-a3c7b6adbab7",
+      "beam": 23,
+      "detector": 0,
+      "crystal": 23,
+      "imageset": 23
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "5c47fbdb-a399-50d7-782e-3680c07663a2",
+      "beam": 24,
+      "detector": 0,
+      "crystal": 24,
+      "imageset": 24
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "3b97f88a-0b48-9b5e-b09b-f86895c7ac0e",
+      "beam": 25,
+      "detector": 0,
+      "crystal": 25,
+      "imageset": 25
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "892b293b-a33d-5458-8f14-3381f4c56c4a",
+      "beam": 26,
+      "detector": 0,
+      "crystal": 26,
+      "imageset": 26
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "b694bc03-b4ab-38de-d598-a32406ce1274",
+      "beam": 27,
+      "detector": 0,
+      "crystal": 27,
+      "imageset": 27
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "f3ca72a2-abae-ff3d-c926-e11ca6f2b847",
+      "beam": 28,
+      "detector": 0,
+      "crystal": 28,
+      "imageset": 28
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "9b9f42a7-c5f6-26c4-007b-6020c09921a8",
+      "beam": 29,
+      "detector": 0,
+      "crystal": 29,
+      "imageset": 29
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "46009f8e-7a15-f099-4f5d-fbb8045c65fe",
+      "beam": 30,
+      "detector": 0,
+      "crystal": 30,
+      "imageset": 30
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "5efbae80-4dff-b83a-f11c-ac4653cf986f",
+      "beam": 31,
+      "detector": 0,
+      "crystal": 31,
+      "imageset": 31
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "b1795026-45c8-efab-2b61-da84d09816c8",
+      "beam": 32,
+      "detector": 0,
+      "crystal": 32,
+      "imageset": 32
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "6b1c5be6-4161-2cf2-2459-1dfc5eed6912",
+      "beam": 33,
+      "detector": 0,
+      "crystal": 33,
+      "imageset": 33
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "3261b4d0-d37c-b0ef-de76-145b0c6851c3",
+      "beam": 34,
+      "detector": 0,
+      "crystal": 34,
+      "imageset": 34
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "e28e4853-7d06-53eb-5059-d9c0edcd83b8",
+      "beam": 35,
+      "detector": 0,
+      "crystal": 35,
+      "imageset": 35
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "6fe16c33-c042-f444-18a9-30e6986ada72",
+      "beam": 36,
+      "detector": 0,
+      "crystal": 36,
+      "imageset": 36
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "aaa2de8d-6f28-8be9-311a-f671b3468860",
+      "beam": 37,
+      "detector": 0,
+      "crystal": 37,
+      "imageset": 37
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "816aec51-782e-ddfa-0e39-e7a006ce57a0",
+      "beam": 38,
+      "detector": 0,
+      "crystal": 38,
+      "imageset": 38
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "663dc6a3-1347-af20-a251-7125885096eb",
+      "beam": 39,
+      "detector": 0,
+      "crystal": 39,
+      "imageset": 39
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "1fd0d5d8-a282-39a4-963f-a157293ee4dc",
+      "beam": 40,
+      "detector": 0,
+      "crystal": 40,
+      "imageset": 40
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "a42b34a3-8e23-2257-c051-45078c8376dc",
+      "beam": 41,
+      "detector": 0,
+      "crystal": 41,
+      "imageset": 41
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "d9c476ea-56aa-03d3-e79e-ab24a2b86bb5",
+      "beam": 42,
+      "detector": 0,
+      "crystal": 42,
+      "imageset": 42
+    },
+    {
+      "__id__": "Experiment",
+      "identifier": "36ae7eb1-62b3-16fd-750d-9d2f62230405",
+      "beam": 43,
+      "detector": 0,
+      "crystal": 43,
+      "imageset": 43
+    }
+  ],
+  "imageset": [
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0001.h5"
+      ],
+      "single_file_indices": [
+        25
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0003.h5"
+      ],
+      "single_file_indices": [
+        1995
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0005.h5"
+      ],
+      "single_file_indices": [
+        2162
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0002.h5"
+      ],
+      "single_file_indices": [
+        1974
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0005.h5"
+      ],
+      "single_file_indices": [
+        207
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0001.h5"
+      ],
+      "single_file_indices": [
+        1268
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0003.h5"
+      ],
+      "single_file_indices": [
+        2736
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0006.h5"
+      ],
+      "single_file_indices": [
+        1407
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0003.h5"
+      ],
+      "single_file_indices": [
+        1505
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0005.h5"
+      ],
+      "single_file_indices": [
+        1523
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0002.h5"
+      ],
+      "single_file_indices": [
+        2291
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0005.h5"
+      ],
+      "single_file_indices": [
+        570
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0002.h5"
+      ],
+      "single_file_indices": [
+        2015
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0004.h5"
+      ],
+      "single_file_indices": [
+        2233
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0001.h5"
+      ],
+      "single_file_indices": [
+        1822
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0003.h5"
+      ],
+      "single_file_indices": [
+        2525
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0006.h5"
+      ],
+      "single_file_indices": [
+        152
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0003.h5"
+      ],
+      "single_file_indices": [
+        596
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0005.h5"
+      ],
+      "single_file_indices": [
+        114
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0002.h5"
+      ],
+      "single_file_indices": [
+        1449
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0004.h5"
+      ],
+      "single_file_indices": [
+        2379
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0002.h5"
+      ],
+      "single_file_indices": [
+        556
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0004.h5"
+      ],
+      "single_file_indices": [
+        956
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0001.h5"
+      ],
+      "single_file_indices": [
+        1871
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0004.h5"
+      ],
+      "single_file_indices": [
+        187
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0005.h5"
+      ],
+      "single_file_indices": [
+        2887
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0003.h5"
+      ],
+      "single_file_indices": [
+        277
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0005.h5"
+      ],
+      "single_file_indices": [
+        238
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0002.h5"
+      ],
+      "single_file_indices": [
+        774
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0004.h5"
+      ],
+      "single_file_indices": [
+        345
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0002.h5"
+      ],
+      "single_file_indices": [
+        505
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0004.h5"
+      ],
+      "single_file_indices": [
+        742
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0001.h5"
+      ],
+      "single_file_indices": [
+        651
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0003.h5"
+      ],
+      "single_file_indices": [
+        2017
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0001.h5"
+      ],
+      "single_file_indices": [
+        32
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0003.h5"
+      ],
+      "single_file_indices": [
+        1716
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0001.h5"
+      ],
+      "single_file_indices": [
+        46
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0003.h5"
+      ],
+      "single_file_indices": [
+        2445
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0006.h5"
+      ],
+      "single_file_indices": [
+        1021
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0003.h5"
+      ],
+      "single_file_indices": [
+        1540
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0005.h5"
+      ],
+      "single_file_indices": [
+        2088
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0002.h5"
+      ],
+      "single_file_indices": [
+        2468
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0005.h5"
+      ],
+      "single_file_indices": [
+        523
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    },
+    {
+      "__id__": "ImageSet",
+      "images": [
+        "/global/cfs/cdirs/m3562/sf_bernina_data_p20231/assembled/135/acq0002.h5"
+      ],
+      "single_file_indices": [
+        412
+      ],
+      "mask": null,
+      "gain": null,
+      "pedestal": null,
+      "dx": null,
+      "dy": null,
+      "params": {}
+    }
+  ],
+  "beam": [
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8908411250238601,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8901275913989661,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8907413195156342,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8909264047438017,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8925315911152343,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8907120214493658,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8895318130850496,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8896235588550623,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8899371756274528,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8903752045553137,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8904098498048532,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8909610093044456,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8903626311863533,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8908444916128309,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8903728398610844,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8908180214757588,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8915290644054126,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.890046539162933,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8898878404760524,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8906645768538763,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8913418303880938,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8904866005840797,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8914422056930702,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8912572199760052,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8918673639785801,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8906906349632373,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8905587212002775,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8901791873461058,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8909198011228001,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.890636977397445,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8917627816663316,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8910344888853714,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8901795130530301,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8900381583743102,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8900676005601542,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8891933885534042,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8916360482610663,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8897473401310751,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.892119003456425,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8906897370211007,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.890748639370203,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8899084830220483,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.8905617630098812,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    },
+    {
+      "direction": [
+        -0.0,
+        -0.0,
+        1.0
+      ],
+      "wavelength": 1.889741992521229,
+      "divergence": 0.0,
+      "sigma_divergence": 0.0,
+      "polarization_normal": [
+        0.0,
+        1.0,
+        0.0
+      ],
+      "polarization_fraction": 0.999,
+      "flux": 0.0,
+      "transmission": 1.0
+    }
+  ],
+  "detector": [
+    {
+      "panels": [
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M0A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999984140169291,
+            -0.0017810007373656254,
+            0.0
+          ],
+          "slow_axis": [
+            0.0017810007373656254,
+            0.9999984140169291,
+            0.0
+          ],
+          "origin": [
+            -38.58423053508638,
+            -19.131359799099098,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M0A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999984140169291,
+            -0.0017810007373656254,
+            0.0
+          ],
+          "slow_axis": [
+            0.0017810007373656254,
+            0.9999984140169291,
+            0.0
+          ],
+          "origin": [
+            -19.23421284881458,
+            -19.16582224952325,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M0A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999984140169291,
+            -0.0017810007373656254,
+            0.0
+          ],
+          "slow_axis": [
+            0.0017810007373656254,
+            0.9999984140169291,
+            0.0
+          ],
+          "origin": [
+            0.11580483745721785,
+            -19.2002846999474,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M0A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999984140169291,
+            -0.0017810007373656254,
+            0.0
+          ],
+          "slow_axis": [
+            0.0017810007373656254,
+            0.9999984140169291,
+            0.0
+          ],
+          "origin": [
+            19.465822523729017,
+            -19.23474715037155,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M0A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999984140169291,
+            -0.0017810007373656254,
+            0.0
+          ],
+          "slow_axis": [
+            0.0017810007373656254,
+            0.9999984140169291,
+            0.0
+          ],
+          "origin": [
+            -38.549768084662226,
+            0.21865788717270007,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M0A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999984140169291,
+            -0.0017810007373656254,
+            0.0
+          ],
+          "slow_axis": [
+            0.0017810007373656254,
+            0.9999984140169291,
+            0.0
+          ],
+          "origin": [
+            -19.199750398390428,
+            0.1841954367485492,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M0A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999984140169291,
+            -0.0017810007373656254,
+            0.0
+          ],
+          "slow_axis": [
+            0.0017810007373656254,
+            0.9999984140169291,
+            0.0
+          ],
+          "origin": [
+            0.15026728788136878,
+            0.14973298632439835,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M0A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999984140169291,
+            -0.0017810007373656254,
+            0.0
+          ],
+          "slow_axis": [
+            0.0017810007373656254,
+            0.9999984140169291,
+            0.0
+          ],
+          "origin": [
+            19.500284974153168,
+            0.1152705359002475,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M12A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999960939635133,
+            0.002795005852663136,
+            0.0
+          ],
+          "slow_axis": [
+            -0.002795005852663136,
+            0.9999960939635133,
+            0.0
+          ],
+          "origin": [
+            -38.49628155062619,
+            -19.307720749021495,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M12A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999960939635133,
+            0.002795005852663136,
+            0.0
+          ],
+          "slow_axis": [
+            -0.002795005852663136,
+            0.9999960939635133,
+            0.0
+          ],
+          "origin": [
+            -19.146308757500222,
+            -19.253637250563717,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M12A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999960939635133,
+            0.002795005852663136,
+            0.0
+          ],
+          "slow_axis": [
+            -0.002795005852663136,
+            0.9999960939635133,
+            0.0
+          ],
+          "origin": [
+            0.203664035625744,
+            -19.19955375210594,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M12A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999960939635133,
+            0.002795005852663136,
+            0.0
+          ],
+          "slow_axis": [
+            -0.002795005852663136,
+            0.9999960939635133,
+            0.0
+          ],
+          "origin": [
+            19.553636828751717,
+            -19.14547025364816,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M12A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999960939635133,
+            0.002795005852663136,
+            0.0
+          ],
+          "slow_axis": [
+            -0.002795005852663136,
+            0.9999960939635133,
+            0.0
+          ],
+          "origin": [
+            -38.55036504908397,
+            0.042252044104472475,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M12A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999960939635133,
+            0.002795005852663136,
+            0.0
+          ],
+          "slow_axis": [
+            -0.002795005852663136,
+            0.9999960939635133,
+            0.0
+          ],
+          "origin": [
+            -19.200392255958,
+            0.09633554256225096,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M12A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999960939635133,
+            0.002795005852663136,
+            0.0
+          ],
+          "slow_axis": [
+            -0.002795005852663136,
+            0.9999960939635133,
+            0.0
+          ],
+          "origin": [
+            0.14958053716796615,
+            0.15041904102002945,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M12A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999960939635133,
+            0.002795005852663136,
+            0.0
+          ],
+          "slow_axis": [
+            -0.002795005852663136,
+            0.9999960939635133,
+            0.0
+          ],
+          "origin": [
+            19.49955333029394,
+            0.20450253947780794,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M13A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999694954405,
+            0.00024700023946561323,
+            0.0
+          ],
+          "slow_axis": [
+            -0.00024700023946561323,
+            0.9999999694954405,
+            0.0
+          ],
+          "origin": [
+            -38.54535278283345,
+            -19.209569297467098,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M13A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999694954405,
+            0.00024700023946561323,
+            0.0
+          ],
+          "slow_axis": [
+            -0.00024700023946561323,
+            0.9999999694954405,
+            0.0
+          ],
+          "origin": [
+            -19.195304997977217,
+            -19.204789830884774,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M13A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999694954405,
+            0.00024700023946561323,
+            0.0
+          ],
+          "slow_axis": [
+            -0.00024700023946561323,
+            0.9999999694954405,
+            0.0
+          ],
+          "origin": [
+            0.1547427868790241,
+            -19.200010364302447,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M13A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999694954405,
+            0.00024700023946561323,
+            0.0
+          ],
+          "slow_axis": [
+            -0.00024700023946561323,
+            0.9999999694954405,
+            0.0
+          ],
+          "origin": [
+            19.504790571735253,
+            -19.195230897720123,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M13A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999694954405,
+            0.00024700023946561323,
+            0.0
+          ],
+          "slow_axis": [
+            -0.00024700023946561323,
+            0.9999999694954405,
+            0.0
+          ],
+          "origin": [
+            -38.550132249415775,
+            0.1404784873891387,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M13A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999694954405,
+            0.00024700023946561323,
+            0.0
+          ],
+          "slow_axis": [
+            -0.00024700023946561323,
+            0.9999999694954405,
+            0.0
+          ],
+          "origin": [
+            -19.20008446455954,
+            0.14525795397146268,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M13A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999694954405,
+            0.00024700023946561323,
+            0.0
+          ],
+          "slow_axis": [
+            -0.00024700023946561323,
+            0.9999999694954405,
+            0.0
+          ],
+          "origin": [
+            0.149963320296698,
+            0.1500374205537902,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M13A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999694954405,
+            0.00024700023946561323,
+            0.0
+          ],
+          "slow_axis": [
+            -0.00024700023946561323,
+            0.9999999694954405,
+            0.0
+          ],
+          "origin": [
+            19.50001110515293,
+            0.1548168871361142,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M1A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999977506735933,
+            -0.0021210015921834676,
+            0.0
+          ],
+          "slow_axis": [
+            0.0021210015921834676,
+            0.9999977506735933,
+            0.0
+          ],
+          "origin": [
+            -38.59073299586943,
+            -19.118239997154316,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M1A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999977506735933,
+            -0.0021210015921834676,
+            0.0
+          ],
+          "slow_axis": [
+            0.0021210015921834676,
+            0.9999977506735933,
+            0.0
+          ],
+          "origin": [
+            -19.24072814532327,
+            -19.159281480566772,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M1A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999977506735933,
+            -0.0021210015921834676,
+            0.0
+          ],
+          "slow_axis": [
+            0.0021210015921834676,
+            0.9999977506735933,
+            0.0
+          ],
+          "origin": [
+            0.1092767052228882,
+            -19.200322963979232,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M1A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999977506735933,
+            -0.0021210015921834676,
+            0.0
+          ],
+          "slow_axis": [
+            0.0021210015921834676,
+            0.9999977506735933,
+            0.0
+          ],
+          "origin": [
+            19.459281555769046,
+            -19.24136444739169,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M1A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999977506735933,
+            -0.0021210015921834676,
+            0.0
+          ],
+          "slow_axis": [
+            0.0021210015921834676,
+            0.9999977506735933,
+            0.0
+          ],
+          "origin": [
+            -38.549691512456974,
+            0.23176485339184438,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M1A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999977506735933,
+            -0.0021210015921834676,
+            0.0
+          ],
+          "slow_axis": [
+            0.0021210015921834676,
+            0.9999977506735933,
+            0.0
+          ],
+          "origin": [
+            -19.199686661910814,
+            0.19072336997938777,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M1A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999977506735933,
+            -0.0021210015921834676,
+            0.0
+          ],
+          "slow_axis": [
+            0.0021210015921834676,
+            0.9999977506735933,
+            0.0
+          ],
+          "origin": [
+            0.15031818863534682,
+            0.1496818865669276,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M1A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999977506735933,
+            -0.0021210015921834676,
+            0.0
+          ],
+          "slow_axis": [
+            0.0021210015921834676,
+            0.9999977506735933,
+            0.0
+          ],
+          "origin": [
+            19.500323039181502,
+            0.10864040315447099,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M4A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999998694266723,
+            -0.0016160027379432385,
+            0.0
+          ],
+          "slow_axis": [
+            0.0016160027379432385,
+            0.999998694266723,
+            0.0
+          ],
+          "origin": [
+            -38.58107336923411,
+            -19.137725868688044,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M4A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999998694266723,
+            -0.0016160027379432385,
+            0.0
+          ],
+          "slow_axis": [
+            0.0016160027379432385,
+            0.999998694266723,
+            0.0
+          ],
+          "origin": [
+            -19.23105026011525,
+            -19.168995599841576,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M4A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999998694266723,
+            -0.0016160027379432385,
+            0.0
+          ],
+          "slow_axis": [
+            0.0016160027379432385,
+            0.999998694266723,
+            0.0
+          ],
+          "origin": [
+            0.11897284900361987,
+            -19.200265330995105,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M4A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999998694266723,
+            -0.0016160027379432385,
+            0.0
+          ],
+          "slow_axis": [
+            0.0016160027379432385,
+            0.999998694266723,
+            0.0
+          ],
+          "origin": [
+            19.468995958122484,
+            -19.231535062148634,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M4A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999998694266723,
+            -0.0016160027379432385,
+            0.0
+          ],
+          "slow_axis": [
+            0.0016160027379432385,
+            0.999998694266723,
+            0.0
+          ],
+          "origin": [
+            -38.54980363808058,
+            0.21229724043082143,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M4A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999998694266723,
+            -0.0016160027379432385,
+            0.0
+          ],
+          "slow_axis": [
+            0.0016160027379432385,
+            0.999998694266723,
+            0.0
+          ],
+          "origin": [
+            -19.199780528961718,
+            0.18102750927728906,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M4A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999998694266723,
+            -0.0016160027379432385,
+            0.0
+          ],
+          "slow_axis": [
+            0.0016160027379432385,
+            0.999998694266723,
+            0.0
+          ],
+          "origin": [
+            0.15024258015714942,
+            0.14975777812376023,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M4A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999998694266723,
+            -0.0016160027379432385,
+            0.0
+          ],
+          "slow_axis": [
+            0.0016160027379432385,
+            0.999998694266723,
+            0.0
+          ],
+          "origin": [
+            19.500265689276013,
+            0.11848804697023141,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M5A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            1.0,
+            0.0,
+            0.0
+          ],
+          "slow_axis": [
+            0.0,
+            1.0,
+            0.0
+          ],
+          "origin": [
+            -38.55009637524094,
+            -19.200048000120002,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M5A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            1.0,
+            0.0,
+            0.0
+          ],
+          "slow_axis": [
+            0.0,
+            1.0,
+            0.0
+          ],
+          "origin": [
+            -19.200048000120002,
+            -19.200048000120002,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M5A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            1.0,
+            0.0,
+            0.0
+          ],
+          "slow_axis": [
+            0.0,
+            1.0,
+            0.0
+          ],
+          "origin": [
+            0.15000037500093555,
+            -19.200048000120002,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M5A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            1.0,
+            0.0,
+            0.0
+          ],
+          "slow_axis": [
+            0.0,
+            1.0,
+            0.0
+          ],
+          "origin": [
+            19.500048750121877,
+            -19.200048000120002,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M5A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            1.0,
+            0.0,
+            0.0
+          ],
+          "slow_axis": [
+            0.0,
+            1.0,
+            0.0
+          ],
+          "origin": [
+            -38.55009637524094,
+            0.1500003750009391,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M5A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            1.0,
+            0.0,
+            0.0
+          ],
+          "slow_axis": [
+            0.0,
+            1.0,
+            0.0
+          ],
+          "origin": [
+            -19.200048000120002,
+            0.1500003750009391,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M5A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            1.0,
+            0.0,
+            0.0
+          ],
+          "slow_axis": [
+            0.0,
+            1.0,
+            0.0
+          ],
+          "origin": [
+            0.15000037500093555,
+            0.1500003750009391,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M5A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            1.0,
+            0.0,
+            0.0
+          ],
+          "slow_axis": [
+            0.0,
+            1.0,
+            0.0
+          ],
+          "origin": [
+            19.500048750121877,
+            0.1500003750009391,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M8A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999938188551362,
+            0.003515999363090838,
+            0.0
+          ],
+          "slow_axis": [
+            -0.003515999363090838,
+            0.9999938188551362,
+            0.0
+          ],
+          "origin": [
+            -38.48235073497099,
+            -19.335471436144353,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M8A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999938188551362,
+            0.003515999363090838,
+            0.0
+          ],
+          "slow_axis": [
+            -0.003515999363090838,
+            0.9999938188551362,
+            0.0
+          ],
+          "origin": [
+            -19.132421965302182,
+            -19.26743667838165,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M8A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999938188551362,
+            0.003515999363090838,
+            0.0
+          ],
+          "slow_axis": [
+            -0.003515999363090838,
+            0.9999938188551362,
+            0.0
+          ],
+          "origin": [
+            0.217506804366622,
+            -19.19940192061895,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M8A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999938188551362,
+            0.003515999363090838,
+            0.0
+          ],
+          "slow_axis": [
+            -0.003515999363090838,
+            0.9999938188551362,
+            0.0
+          ],
+          "origin": [
+            19.56743557403543,
+            -19.131367162856247,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M8A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999938188551362,
+            0.003515999363090838,
+            0.0
+          ],
+          "slow_axis": [
+            -0.003515999363090838,
+            0.9999938188551362,
+            0.0
+          ],
+          "origin": [
+            -38.550385492733696,
+            0.014457333524454441,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M8A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999938188551362,
+            0.003515999363090838,
+            0.0
+          ],
+          "slow_axis": [
+            -0.003515999363090838,
+            0.9999938188551362,
+            0.0
+          ],
+          "origin": [
+            -19.200456723064885,
+            0.08249209128715762,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M8A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999938188551362,
+            0.003515999363090838,
+            0.0
+          ],
+          "slow_axis": [
+            -0.003515999363090838,
+            0.9999938188551362,
+            0.0
+          ],
+          "origin": [
+            0.1494720466039199,
+            0.15052684904985725,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M8A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999938188551362,
+            0.003515999363090838,
+            0.0
+          ],
+          "slow_axis": [
+            -0.003515999363090838,
+            0.9999938188551362,
+            0.0
+          ],
+          "origin": [
+            19.499400816272725,
+            0.21856160681256043,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M9A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999996619995,
+            2.6000025991237982e-05,
+            0.0
+          ],
+          "slow_axis": [
+            -2.6000025991237982e-05,
+            0.9999999996619995,
+            0.0
+          ],
+          "origin": [
+            -38.549597160463954,
+            -19.201050297138096,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M9A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999996619995,
+            2.6000025991237982e-05,
+            0.0
+          ],
+          "slow_axis": [
+            -2.6000025991237982e-05,
+            0.9999999996619995,
+            0.0
+          ],
+          "origin": [
+            -19.199548791883338,
+            -19.20054719537741,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M9A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999996619995,
+            2.6000025991237982e-05,
+            0.0
+          ],
+          "slow_axis": [
+            -2.6000025991237982e-05,
+            0.9999999996619995,
+            0.0
+          ],
+          "origin": [
+            0.1504995766972731,
+            -19.200044093616725,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M9A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999996619995,
+            2.6000025991237982e-05,
+            0.0
+          ],
+          "slow_axis": [
+            -2.6000025991237982e-05,
+            0.9999999996619995,
+            0.0
+          ],
+          "origin": [
+            19.500547945277884,
+            -19.19954099185604,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M9A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999996619995,
+            2.6000025991237982e-05,
+            0.0
+          ],
+          "slow_axis": [
+            -2.6000025991237982e-05,
+            0.9999999996619995,
+            0.0
+          ],
+          "origin": [
+            -38.55010026222464,
+            0.14899807144251653,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M9A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999996619995,
+            2.6000025991237982e-05,
+            0.0
+          ],
+          "slow_axis": [
+            -2.6000025991237982e-05,
+            0.9999999996619995,
+            0.0
+          ],
+          "origin": [
+            -19.200051893644023,
+            0.1495011732032019,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M9A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999996619995,
+            2.6000025991237982e-05,
+            0.0
+          ],
+          "slow_axis": [
+            -2.6000025991237982e-05,
+            0.9999999996619995,
+            0.0
+          ],
+          "origin": [
+            0.14999647493658821,
+            0.15000427496388724,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q0M9A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999996619995,
+            2.6000025991237982e-05,
+            0.0
+          ],
+          "slow_axis": [
+            -2.6000025991237982e-05,
+            0.9999999996619995,
+            0.0
+          ],
+          "origin": [
+            19.5000448435172,
+            0.1505073767245726,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M10A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997570951027,
+            0.0006970005276958143,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006970005276958143,
+            0.9999997570951027,
+            0.0
+          ],
+          "origin": [
+            -38.53670456764587,
+            -19.226912773850582,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M10A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997570951027,
+            0.0006970005276958143,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006970005276958143,
+            0.9999997570951027,
+            0.0
+          ],
+          "origin": [
+            -19.186660892746445,
+            -19.213425779922183,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M10A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997570951027,
+            0.0006970005276958143,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006970005276958143,
+            0.9999997570951027,
+            0.0
+          ],
+          "origin": [
+            0.16338278215298305,
+            -19.199938785993783,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M10A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997570951027,
+            0.0006970005276958143,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006970005276958143,
+            0.9999997570951027,
+            0.0
+          ],
+          "origin": [
+            19.513426457052407,
+            -19.186451792065387,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M10A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997570951027,
+            0.0006970005276958143,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006970005276958143,
+            0.9999997570951027,
+            0.0
+          ],
+          "origin": [
+            -38.55019156157427,
+            0.12313090104884239,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M10A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997570951027,
+            0.0006970005276958143,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006970005276958143,
+            0.9999997570951027,
+            0.0
+          ],
+          "origin": [
+            -19.200147886674845,
+            0.13661789497724186,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M10A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997570951027,
+            0.0006970005276958143,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006970005276958143,
+            0.9999997570951027,
+            0.0
+          ],
+          "origin": [
+            0.14989578822458421,
+            0.15010488890564133,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M10A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997570951027,
+            0.0006970005276958143,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006970005276958143,
+            0.9999997570951027,
+            0.0
+          ],
+          "origin": [
+            19.499939463124008,
+            0.16359188283403725,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M11A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997913416481,
+            0.0006460005112072156,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006460005112072156,
+            0.9999997913416481,
+            0.0
+          ],
+          "origin": [
+            -38.53768509061809,
+            -19.224947375835125,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M11A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997913416481,
+            0.0006460005112072156,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006460005112072156,
+            0.9999997913416481,
+            0.0
+          ],
+          "origin": [
+            -19.18764075304635,
+            -19.212447234692913,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M11A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997913416481,
+            0.0006460005112072156,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006460005112072156,
+            0.9999997913416481,
+            0.0
+          ],
+          "origin": [
+            0.1624035845253882,
+            -19.199947093550698,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M11A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997913416481,
+            0.0006460005112072156,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006460005112072156,
+            0.9999997913416481,
+            0.0
+          ],
+          "origin": [
+            19.512447922097127,
+            -19.187446952408486,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M11A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997913416481,
+            0.0006460005112072156,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006460005112072156,
+            0.9999997913416481,
+            0.0
+          ],
+          "origin": [
+            -38.5501852317603,
+            0.1250969617366131,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M11A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997913416481,
+            0.0006460005112072156,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006460005112072156,
+            0.9999997913416481,
+            0.0
+          ],
+          "origin": [
+            -19.20014089418856,
+            0.13759710287882498,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M11A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997913416481,
+            0.0006460005112072156,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006460005112072156,
+            0.9999997913416481,
+            0.0
+          ],
+          "origin": [
+            0.1499034433831757,
+            0.1500972440210404,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M11A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997913416481,
+            0.0006460005112072156,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006460005112072156,
+            0.9999997913416481,
+            0.0
+          ],
+          "origin": [
+            19.499947780954916,
+            0.16259738516325228,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M14A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999752191101,
+            0.0007040012335450021,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0007040012335450021,
+            0.999999752191101,
+            0.0
+          ],
+          "origin": [
+            -38.536569964707795,
+            -19.22718255757869,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M14A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999752191101,
+            0.0007040012335450021,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0007040012335450021,
+            0.999999752191101,
+            0.0
+          ],
+          "origin": [
+            -19.18652638470104,
+            -19.21356009965345,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M14A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999752191101,
+            0.0007040012335450021,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0007040012335450021,
+            0.999999752191101,
+            0.0
+          ],
+          "origin": [
+            0.163517195305715,
+            -19.19993764172821,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M14A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999752191101,
+            0.0007040012335450021,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0007040012335450021,
+            0.999999752191101,
+            0.0
+          ],
+          "origin": [
+            19.51356077531247,
+            -19.186315183802968,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M14A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999752191101,
+            0.0007040012335450021,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0007040012335450021,
+            0.999999752191101,
+            0.0
+          ],
+          "origin": [
+            -38.55019242263304,
+            0.12286102242806507,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M14A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999752191101,
+            0.0007040012335450021,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0007040012335450021,
+            0.999999752191101,
+            0.0
+          ],
+          "origin": [
+            -19.20014884262628,
+            0.1364834803533057,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M14A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999752191101,
+            0.0007040012335450021,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0007040012335450021,
+            0.999999752191101,
+            0.0
+          ],
+          "origin": [
+            0.1498947373804744,
+            0.15010593827854635,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M14A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999752191101,
+            0.0007040012335450021,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0007040012335450021,
+            0.999999752191101,
+            0.0
+          ],
+          "origin": [
+            19.49993831738723,
+            0.16372839620378699,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M15A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999998351066185,
+            0.0018160024535435523,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0018160024535435523,
+            0.999998351066185,
+            0.0
+          ],
+          "origin": [
+            -38.515165474407084,
+            -19.27002341011338,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M15A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999998351066185,
+            0.0018160024535435523,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0018160024535435523,
+            0.999998351066185,
+            0.0
+          ],
+          "origin": [
+            -19.165149006235232,
+            -19.234883674787973,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M15A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999998351066185,
+            0.0018160024535435523,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0018160024535435523,
+            0.999998351066185,
+            0.0
+          ],
+          "origin": [
+            0.1848674619366178,
+            -19.199743939462568,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M15A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999998351066185,
+            0.0018160024535435523,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0018160024535435523,
+            0.999998351066185,
+            0.0
+          ],
+          "origin": [
+            19.534883930108478,
+            -19.164604204137163,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M15A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999998351066185,
+            0.0018160024535435523,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0018160024535435523,
+            0.999998351066185,
+            0.0
+          ],
+          "origin": [
+            -38.55030520973249,
+            0.07999305805847001,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M15A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999998351066185,
+            0.0018160024535435523,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0018160024535435523,
+            0.999998351066185,
+            0.0
+          ],
+          "origin": [
+            -19.20028874156064,
+            0.1151327933838786,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M15A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999998351066185,
+            0.0018160024535435523,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0018160024535435523,
+            0.999998351066185,
+            0.0
+          ],
+          "origin": [
+            0.14972772661121173,
+            0.15027252870928365,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M15A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999998351066185,
+            0.0018160024535435523,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0018160024535435523,
+            0.999998351066185,
+            0.0
+          ],
+          "origin": [
+            19.49974419478307,
+            0.1854122640346887,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M2A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999995139004101,
+            0.0009860014927087898,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0009860014927087898,
+            0.9999995139004101,
+            0.0
+          ],
+          "origin": [
+            -38.531146360066714,
+            -19.238049119554596,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M2A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999995139004101,
+            0.0009860014927087898,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0009860014927087898,
+            0.9999995139004101,
+            0.0
+          ],
+          "origin": [
+            -19.181107390996353,
+            -19.21896994297274,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M2A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999995139004101,
+            0.0009860014927087898,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0009860014927087898,
+            0.9999995139004101,
+            0.0
+          ],
+          "origin": [
+            0.16893157807401002,
+            -19.199890766390883,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M2A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999995139004101,
+            0.0009860014927087898,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0009860014927087898,
+            0.9999995139004101,
+            0.0
+          ],
+          "origin": [
+            19.51897054714437,
+            -19.18081158980903,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M2A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999995139004101,
+            0.0009860014927087898,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0009860014927087898,
+            0.9999995139004101,
+            0.0
+          ],
+          "origin": [
+            -38.55022553664857,
+            0.11198984951576563,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M2A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999995139004101,
+            0.0009860014927087898,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0009860014927087898,
+            0.9999995139004101,
+            0.0
+          ],
+          "origin": [
+            -19.200186567578207,
+            0.13106902609762017,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M2A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999995139004101,
+            0.0009860014927087898,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0009860014927087898,
+            0.9999995139004101,
+            0.0
+          ],
+          "origin": [
+            0.1498524014921535,
+            0.15014820267947826,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M2A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999995139004101,
+            0.0009860014927087898,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0009860014927087898,
+            0.9999995139004101,
+            0.0
+          ],
+          "origin": [
+            19.499891370562516,
+            0.1692273792613328,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M3A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999997354996,
+            -2.3000022993939486e-05,
+            0.0
+          ],
+          "slow_axis": [
+            2.3000022993939486e-05,
+            0.9999999997354996,
+            0.0
+          ],
+          "origin": [
+            -38.550537966589914,
+            -19.199161341938535,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M3A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999997354996,
+            -2.3000022993939486e-05,
+            0.0
+          ],
+          "slow_axis": [
+            2.3000022993939486e-05,
+            0.9999999997354996,
+            0.0
+          ],
+          "origin": [
+            -19.200489596587072,
+            -19.199606393496097,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M3A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999997354996,
+            -2.3000022993939486e-05,
+            0.0
+          ],
+          "slow_axis": [
+            2.3000022993939486e-05,
+            0.9999999997354996,
+            0.0
+          ],
+          "origin": [
+            0.149558773415777,
+            -19.20005144505366,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M3A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999997354996,
+            -2.3000022993939486e-05,
+            0.0
+          ],
+          "slow_axis": [
+            2.3000022993939486e-05,
+            0.9999999997354996,
+            0.0
+          ],
+          "origin": [
+            19.499607143418622,
+            -19.20049649661122,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M3A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999997354996,
+            -2.3000022993939486e-05,
+            0.0
+          ],
+          "slow_axis": [
+            2.3000022993939486e-05,
+            0.9999999997354996,
+            0.0
+          ],
+          "origin": [
+            -38.55009291503235,
+            0.15088702806431087,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M3A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999997354996,
+            -2.3000022993939486e-05,
+            0.0
+          ],
+          "slow_axis": [
+            2.3000022993939486e-05,
+            0.9999999997354996,
+            0.0
+          ],
+          "origin": [
+            -19.20004454502951,
+            0.15044197650674818,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M3A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999997354996,
+            -2.3000022993939486e-05,
+            0.0
+          ],
+          "slow_axis": [
+            2.3000022993939486e-05,
+            0.9999999997354996,
+            0.0
+          ],
+          "origin": [
+            0.1500038249733386,
+            0.14999692494918548,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M3A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999999997354996,
+            -2.3000022993939486e-05,
+            0.0
+          ],
+          "slow_axis": [
+            2.3000022993939486e-05,
+            0.9999999997354996,
+            0.0
+          ],
+          "origin": [
+            19.500052194976185,
+            0.14955187339162634,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M6A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999980733095082,
+            0.0019630021069128854,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0019630021069128854,
+            0.9999980733095082,
+            0.0
+          ],
+          "origin": [
+            -38.51233236645974,
+            -19.27568492797637,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M6A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999980733095082,
+            0.0019630021069128854,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0019630021069128854,
+            0.9999980733095082,
+            0.0
+          ],
+          "origin": [
+            -19.162321272893017,
+            -19.237700742247142,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M6A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999980733095082,
+            0.0019630021069128854,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0019630021069128854,
+            0.9999980733095082,
+            0.0
+          ],
+          "origin": [
+            0.18768982067369952,
+            -19.199716556517913,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M6A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999980733095082,
+            0.0019630021069128854,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0019630021069128854,
+            0.9999980733095082,
+            0.0
+          ],
+          "origin": [
+            19.53770091424042,
+            -19.161732370788684,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M6A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999980733095082,
+            0.0019630021069128854,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0019630021069128854,
+            0.9999980733095082,
+            0.0
+          ],
+          "origin": [
+            -38.55031655218897,
+            0.074326165590346,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M6A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999980733095082,
+            0.0019630021069128854,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0019630021069128854,
+            0.9999980733095082,
+            0.0
+          ],
+          "origin": [
+            -19.200305458622246,
+            0.11231035131957512,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M6A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999980733095082,
+            0.0019630021069128854,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0019630021069128854,
+            0.9999980733095082,
+            0.0
+          ],
+          "origin": [
+            0.14970563494447087,
+            0.15029453704880424,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M6A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999980733095082,
+            0.0019630021069128854,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0019630021069128854,
+            0.9999980733095082,
+            0.0
+          ],
+          "origin": [
+            19.499716728511192,
+            0.18827872277803337,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M7A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999998415152207,
+            0.0005630004737735431,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0005630004737735431,
+            0.9999998415152207,
+            0.0
+          ],
+          "origin": [
+            -38.53928062951689,
+            -19.221748679727906,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M7A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999998415152207,
+            0.0005630004737735431,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0005630004737735431,
+            0.9999998415152207,
+            0.0
+          ],
+          "origin": [
+            -19.189235321084098,
+            -19.210854593325173,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M7A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999998415152207,
+            0.0005630004737735431,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0005630004737735431,
+            0.9999998415152207,
+            0.0
+          ],
+          "origin": [
+            0.16080998734869723,
+            -19.19996050692244,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M7A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999998415152207,
+            0.0005630004737735431,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0005630004737735431,
+            0.9999998415152207,
+            0.0
+          ],
+          "origin": [
+            19.510855295781493,
+            -19.189066420519705,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M7A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999998415152207,
+            0.0005630004737735431,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0005630004737735431,
+            0.9999998415152207,
+            0.0
+          ],
+          "origin": [
+            -38.550174715919624,
+            0.1282966287048879,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M7A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999998415152207,
+            0.0005630004737735431,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0005630004737735431,
+            0.9999998415152207,
+            0.0
+          ],
+          "origin": [
+            -19.20012940748683,
+            0.13919071510762038,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M7A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999998415152207,
+            0.0005630004737735431,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0005630004737735431,
+            0.9999998415152207,
+            0.0
+          ],
+          "origin": [
+            0.14991590094596316,
+            0.15008480151035286,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q1M7A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999998415152207,
+            0.0005630004737735431,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0005630004737735431,
+            0.9999998415152207,
+            0.0
+          ],
+          "origin": [
+            19.49996120937876,
+            0.1609788879130889,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M16A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.99999981394968,
+            0.0006100004965098013,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006100004965098013,
+            0.99999981394968,
+            0.0
+          ],
+          "origin": [
+            -38.53837716417008,
+            -19.223560005874322,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M16A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.99999981394968,
+            0.0006100004965098013,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006100004965098013,
+            0.99999981394968,
+            0.0
+          ],
+          "origin": [
+            -19.188332389131837,
+            -19.21175646675801,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M16A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.99999981394968,
+            0.0006100004965098013,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006100004965098013,
+            0.99999981394968,
+            0.0
+          ],
+          "origin": [
+            0.1617123859064053,
+            -19.199952927641696,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M16A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.99999981394968,
+            0.0006100004965098013,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006100004965098013,
+            0.99999981394968,
+            0.0
+          ],
+          "origin": [
+            19.511757160944647,
+            -19.188149388525385,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M16A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.99999981394968,
+            0.0006100004965098013,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006100004965098013,
+            0.99999981394968,
+            0.0
+          ],
+          "origin": [
+            -38.550180703286394,
+            0.12648476916392326,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M16A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.99999981394968,
+            0.0006100004965098013,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006100004965098013,
+            0.99999981394968,
+            0.0
+          ],
+          "origin": [
+            -19.200135928248148,
+            0.13828830828023442,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M16A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.99999981394968,
+            0.0006100004965098013,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006100004965098013,
+            0.99999981394968,
+            0.0
+          ],
+          "origin": [
+            0.14990884679009286,
+            0.15009184739654913,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M16A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.99999981394968,
+            0.0006100004965098013,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0006100004965098013,
+            0.99999981394968,
+            0.0
+          ],
+          "origin": [
+            19.499953621828336,
+            0.16189538651286028,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M17A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999998247676956,
+            -0.000592000488262964,
+            0.0
+          ],
+          "slow_axis": [
+            0.000592000488262964,
+            0.9999998247676956,
+            0.0
+          ],
+          "origin": [
+            -38.561456057809465,
+            -19.177222959774618,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M17A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999998247676956,
+            -0.000592000488262964,
+            0.0
+          ],
+          "slow_axis": [
+            0.000592000488262964,
+            0.9999998247676956,
+            0.0
+          ],
+          "origin": [
+            -19.211411073442093,
+            -19.188678197860604,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M17A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999998247676956,
+            -0.000592000488262964,
+            0.0
+          ],
+          "slow_axis": [
+            0.000592000488262964,
+            0.9999998247676956,
+            0.0
+          ],
+          "origin": [
+            0.13863391092527633,
+            -19.200133435946587,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M17A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999998247676956,
+            -0.000592000488262964,
+            0.0
+          ],
+          "slow_axis": [
+            0.000592000488262964,
+            0.9999998247676956,
+            0.0
+          ],
+          "origin": [
+            19.488678895292647,
+            -19.21158867403257,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M17A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999998247676956,
+            -0.000592000488262964,
+            0.0
+          ],
+          "slow_axis": [
+            0.000592000488262964,
+            0.9999998247676956,
+            0.0
+          ],
+          "origin": [
+            -38.550000819723486,
+            0.17282202459275453,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M17A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999998247676956,
+            -0.000592000488262964,
+            0.0
+          ],
+          "slow_axis": [
+            0.000592000488262964,
+            0.9999998247676956,
+            0.0
+          ],
+          "origin": [
+            -19.199955835356107,
+            0.16136678650676828,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M17A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999998247676956,
+            -0.000592000488262964,
+            0.0
+          ],
+          "slow_axis": [
+            0.000592000488262964,
+            0.9999998247676956,
+            0.0
+          ],
+          "origin": [
+            0.15008914901125991,
+            0.14991154842078558,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M17A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999998247676956,
+            -0.000592000488262964,
+            0.0
+          ],
+          "slow_axis": [
+            0.000592000488262964,
+            0.9999998247676956,
+            0.0
+          ],
+          "origin": [
+            19.500134133378634,
+            0.13845631033480288,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M20A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999999968,
+            8.000007999751999e-06,
+            0.0
+          ],
+          "slow_axis": [
+            -8.000007999751999e-06,
+            0.999999999968,
+            0.0
+          ],
+          "origin": [
+            -38.549942773469745,
+            -19.20035640058499,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M20A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999999968,
+            8.000007999751999e-06,
+            0.0
+          ],
+          "slow_axis": [
+            -8.000007999751999e-06,
+            0.999999999968,
+            0.0
+          ],
+          "origin": [
+            -19.199894398968006,
+            -19.200201600043194,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M20A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999999968,
+            8.000007999751999e-06,
+            0.0
+          ],
+          "slow_axis": [
+            -8.000007999751999e-06,
+            0.999999999968,
+            0.0
+          ],
+          "origin": [
+            0.15015397553372936,
+            -19.200046799501397,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M20A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999999968,
+            8.000007999751999e-06,
+            0.0
+          ],
+          "slow_axis": [
+            -8.000007999751999e-06,
+            0.999999999968,
+            0.0
+          ],
+          "origin": [
+            19.50020235003547,
+            -19.1998919989596,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M20A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999999968,
+            8.000007999751999e-06,
+            0.0
+          ],
+          "slow_axis": [
+            -8.000007999751999e-06,
+            0.999999999968,
+            0.0
+          ],
+          "origin": [
+            -38.55009757401154,
+            0.14969197391674527,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M20A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999999968,
+            8.000007999751999e-06,
+            0.0
+          ],
+          "slow_axis": [
+            -8.000007999751999e-06,
+            0.999999999968,
+            0.0
+          ],
+          "origin": [
+            -19.200049199509802,
+            0.1498467744585419,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M20A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999999968,
+            8.000007999751999e-06,
+            0.0
+          ],
+          "slow_axis": [
+            -8.000007999751999e-06,
+            0.999999999968,
+            0.0
+          ],
+          "origin": [
+            0.1499991749919328,
+            0.1500015750003385,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M20A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999999968,
+            8.000007999751999e-06,
+            0.0
+          ],
+          "slow_axis": [
+            -8.000007999751999e-06,
+            0.999999999968,
+            0.0
+          ],
+          "origin": [
+            19.500047549493672,
+            0.15015637554213512,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M21A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999989283515793,
+            -0.0014639998951066072,
+            0.0
+          ],
+          "slow_axis": [
+            0.0014639998951066072,
+            0.9999989283515793,
+            0.0
+          ],
+          "origin": [
+            -38.578163931349266,
+            -19.143590087369187,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M21A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999989283515793,
+            -0.0014639998951066072,
+            0.0
+          ],
+          "slow_axis": [
+            0.0014639998951066072,
+            0.9999989283515793,
+            0.0
+          ],
+          "origin": [
+            -19.228136292677103,
+            -19.17191855616067,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M21A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999989283515793,
+            -0.0014639998951066072,
+            0.0
+          ],
+          "slow_axis": [
+            0.0014639998951066072,
+            0.9999989283515793,
+            0.0
+          ],
+          "origin": [
+            0.12189134599505826,
+            -19.200247024952155,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M21A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999989283515793,
+            -0.0014639998951066072,
+            0.0
+          ],
+          "slow_axis": [
+            0.0014639998951066072,
+            0.9999989283515793,
+            0.0
+          ],
+          "origin": [
+            19.47191898466722,
+            -19.22857549374364,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M21A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999989283515793,
+            -0.0014639998951066072,
+            0.0
+          ],
+          "slow_axis": [
+            0.0014639998951066072,
+            0.9999989283515793,
+            0.0
+          ],
+          "origin": [
+            -38.54983546255778,
+            0.20643755130297237,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M21A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999989283515793,
+            -0.0014639998951066072,
+            0.0
+          ],
+          "slow_axis": [
+            0.0014639998951066072,
+            0.9999989283515793,
+            0.0
+          ],
+          "origin": [
+            -19.19980782388562,
+            0.17810908251149016,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M21A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999989283515793,
+            -0.0014639998951066072,
+            0.0
+          ],
+          "slow_axis": [
+            0.0014639998951066072,
+            0.9999989283515793,
+            0.0
+          ],
+          "origin": [
+            0.1502198147865431,
+            0.1497806137200044,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M21A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999989283515793,
+            -0.0014639998951066072,
+            0.0
+          ],
+          "slow_axis": [
+            0.0014639998951066072,
+            0.9999989283515793,
+            0.0
+          ],
+          "origin": [
+            19.5002474534587,
+            0.12145214492851863,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M24A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999911505159804,
+            -0.0042070048402691315,
+            0.0
+          ],
+          "slow_axis": [
+            0.0042070048402691315,
+            0.9999911505159804,
+            0.0
+          ],
+          "origin": [
+            -38.630529921649014,
+            -19.03769764755857,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M24A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999911505159804,
+            -0.0042070048402691315,
+            0.0
+          ],
+          "slow_axis": [
+            0.0042070048402691315,
+            0.9999911505159804,
+            0.0
+          ],
+          "origin": [
+            -19.280652784471954,
+            -19.119103394732143,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M24A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999911505159804,
+            -0.0042070048402691315,
+            0.0
+          ],
+          "slow_axis": [
+            0.0042070048402691315,
+            0.9999911505159804,
+            0.0
+          ],
+          "origin": [
+            0.06922435270511158,
+            -19.20050914190572,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M24A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999911505159804,
+            -0.0042070048402691315,
+            0.0
+          ],
+          "slow_axis": [
+            0.0042070048402691315,
+            0.9999911505159804,
+            0.0
+          ],
+          "origin": [
+            19.419101489882173,
+            -19.281914889079296,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M24A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999911505159804,
+            -0.0042070048402691315,
+            0.0
+          ],
+          "slow_axis": [
+            0.0042070048402691315,
+            0.9999911505159804,
+            0.0
+          ],
+          "origin": [
+            -38.54912417447544,
+            0.31217948961849373,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M24A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999911505159804,
+            -0.0042070048402691315,
+            0.0
+          ],
+          "slow_axis": [
+            0.0042070048402691315,
+            0.9999911505159804,
+            0.0
+          ],
+          "origin": [
+            -19.19924703729838,
+            0.23077374244492077,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M24A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999911505159804,
+            -0.0042070048402691315,
+            0.0
+          ],
+          "slow_axis": [
+            0.0042070048402691315,
+            0.9999911505159804,
+            0.0
+          ],
+          "origin": [
+            0.1506300998786872,
+            0.14936799527134426,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M24A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999911505159804,
+            -0.0042070048402691315,
+            0.0
+          ],
+          "slow_axis": [
+            0.0042070048402691315,
+            0.9999911505159804,
+            0.0
+          ],
+          "origin": [
+            19.500507237055746,
+            0.06796224809776774,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M25A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999955627557868,
+            -0.0029790046554774214,
+            0.0
+          ],
+          "slow_axis": [
+            0.0029790046554774214,
+            0.9999955627557868,
+            0.0
+          ],
+          "origin": [
+            -38.60712235142663,
+            -19.085121888247176,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M25A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999955627557868,
+            -0.0029790046554774214,
+            0.0
+          ],
+          "slow_axis": [
+            0.0029790046554774214,
+            0.9999955627557868,
+            0.0
+          ],
+          "origin": [
+            -19.257159837195868,
+            -19.142765772440374,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M25A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999955627557868,
+            -0.0029790046554774214,
+            0.0
+          ],
+          "slow_axis": [
+            0.0029790046554774214,
+            0.9999955627557868,
+            0.0
+          ],
+          "origin": [
+            0.09280267703489505,
+            -19.20040965663357,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M25A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999955627557868,
+            -0.0029790046554774214,
+            0.0
+          ],
+          "slow_axis": [
+            0.0029790046554774214,
+            0.9999955627557868,
+            0.0
+          ],
+          "origin": [
+            19.442765191265657,
+            -19.258053540826772,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M25A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999955627557868,
+            -0.0029790046554774214,
+            0.0
+          ],
+          "slow_axis": [
+            0.0029790046554774214,
+            0.9999955627557868,
+            0.0
+          ],
+          "origin": [
+            -38.549478467233435,
+            0.26484062598358804,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M25A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999955627557868,
+            -0.0029790046554774214,
+            0.0
+          ],
+          "slow_axis": [
+            0.0029790046554774214,
+            0.9999955627557868,
+            0.0
+          ],
+          "origin": [
+            -19.19951595300267,
+            0.2071967417903906,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M25A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999955627557868,
+            -0.0029790046554774214,
+            0.0
+          ],
+          "slow_axis": [
+            0.0029790046554774214,
+            0.9999955627557868,
+            0.0
+          ],
+          "origin": [
+            0.15044656122809363,
+            0.14955285759719317,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M25A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999955627557868,
+            -0.0029790046554774214,
+            0.0
+          ],
+          "slow_axis": [
+            0.0029790046554774214,
+            0.9999955627557868,
+            0.0
+          ],
+          "origin": [
+            19.500409075458855,
+            0.09190897340399218,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M28A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999996613349948,
+            -0.0008230005442792449,
+            0.0
+          ],
+          "slow_axis": [
+            0.0008230005442792449,
+            0.9999996613349948,
+            0.0
+          ],
+          "origin": [
+            -38.565884969626644,
+            -19.168314747436803,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M28A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999996613349948,
+            -0.0008230005442792449,
+            0.0
+          ],
+          "slow_axis": [
+            0.0008230005442792449,
+            0.9999996613349948,
+            0.0
+          ],
+          "origin": [
+            -19.215843147689935,
+            -19.184239847781356,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M28A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999996613349948,
+            -0.0008230005442792449,
+            0.0
+          ],
+          "slow_axis": [
+            0.0008230005442792449,
+            0.9999996613349948,
+            0.0
+          ],
+          "origin": [
+            0.134198674246771,
+            -19.20016494812591,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M28A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999996613349948,
+            -0.0008230005442792449,
+            0.0
+          ],
+          "slow_axis": [
+            0.0008230005442792449,
+            0.9999996613349948,
+            0.0
+          ],
+          "origin": [
+            19.484240496183478,
+            -19.216090048470466,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M28A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999996613349948,
+            -0.0008230005442792449,
+            0.0
+          ],
+          "slow_axis": [
+            0.0008230005442792449,
+            0.9999996613349948,
+            0.0
+          ],
+          "origin": [
+            -38.549959869282084,
+            0.18172707449990355,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M28A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999996613349948,
+            -0.0008230005442792449,
+            0.0
+          ],
+          "slow_axis": [
+            0.0008230005442792449,
+            0.9999996613349948,
+            0.0
+          ],
+          "origin": [
+            -19.19991804734538,
+            0.16580197415535025,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M28A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999996613349948,
+            -0.0008230005442792449,
+            0.0
+          ],
+          "slow_axis": [
+            0.0008230005442792449,
+            0.9999996613349948,
+            0.0
+          ],
+          "origin": [
+            0.15012377459132528,
+            0.14987687381079695,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M28A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999996613349948,
+            -0.0008230005442792449,
+            0.0
+          ],
+          "slow_axis": [
+            0.0008230005442792449,
+            0.9999996613349948,
+            0.0
+          ],
+          "origin": [
+            19.50016559652803,
+            0.1339517734662401,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M29A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999827067455276,
+            -0.005881004156445262,
+            0.0
+          ],
+          "slow_axis": [
+            0.005881004156445262,
+            0.9999827067455276,
+            0.0
+          ],
+          "origin": [
+            -38.662345280707044,
+            -18.973002691789894,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M29A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999827067455276,
+            -0.005881004156445262,
+            0.0
+          ],
+          "slow_axis": [
+            0.005881004156445262,
+            0.9999827067455276,
+            0.0
+          ],
+          "origin": [
+            -19.312631530896706,
+            -19.086800406711397,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M29A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999827067455276,
+            -0.005881004156445262,
+            0.0
+          ],
+          "slow_axis": [
+            0.005881004156445262,
+            0.9999827067455276,
+            0.0
+          ],
+          "origin": [
+            0.03708221891363101,
+            -19.2005981216329,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M29A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999827067455276,
+            -0.005881004156445262,
+            0.0
+          ],
+          "slow_axis": [
+            0.005881004156445262,
+            0.9999827067455276,
+            0.0
+          ],
+          "origin": [
+            19.386795968723966,
+            -19.314395836554404,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M29A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999827067455276,
+            -0.005881004156445262,
+            0.0
+          ],
+          "slow_axis": [
+            0.005881004156445262,
+            0.9999827067455276,
+            0.0
+          ],
+          "origin": [
+            -38.54854756578554,
+            0.37671105802044025,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M29A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999827067455276,
+            -0.005881004156445262,
+            0.0
+          ],
+          "slow_axis": [
+            0.005881004156445262,
+            0.9999827067455276,
+            0.0
+          ],
+          "origin": [
+            -19.198833815975203,
+            0.262913343098937,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M29A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999827067455276,
+            -0.005881004156445262,
+            0.0
+          ],
+          "slow_axis": [
+            0.005881004156445262,
+            0.9999827067455276,
+            0.0
+          ],
+          "origin": [
+            0.15087993383513418,
+            0.14911562817743373,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q2M29A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999827067455276,
+            -0.005881004156445262,
+            0.0
+          ],
+          "slow_axis": [
+            0.005881004156445262,
+            0.9999827067455276,
+            0.0
+          ],
+          "origin": [
+            19.50059368364547,
+            0.03531791325593048,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M18A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999924727858,
+            -0.00038800035879476777,
+            0.0
+          ],
+          "slow_axis": [
+            0.00038800035879476777,
+            0.999999924727858,
+            0.0
+          ],
+          "origin": [
+            -38.557543099005535,
+            -19.185089103666094,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M18A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999924727858,
+            -0.00038800035879476777,
+            0.0
+          ],
+          "slow_axis": [
+            0.00038800035879476777,
+            0.999999924727858,
+            0.0
+          ],
+          "origin": [
+            -19.20749618040419,
+            -19.192596929378336,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M18A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999924727858,
+            -0.00038800035879476777,
+            0.0
+          ],
+          "slow_axis": [
+            0.00038800035879476777,
+            0.999999924727858,
+            0.0
+          ],
+          "origin": [
+            0.1425507381971657,
+            -19.20010475509058,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M18A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999924727858,
+            -0.00038800035879476777,
+            0.0
+          ],
+          "slow_axis": [
+            0.00038800035879476777,
+            0.999999924727858,
+            0.0
+          ],
+          "origin": [
+            19.492597656798516,
+            -19.207612580802824,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M18A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999924727858,
+            -0.00038800035879476777,
+            0.0
+          ],
+          "slow_axis": [
+            0.00038800035879476777,
+            0.999999924727858,
+            0.0
+          ],
+          "origin": [
+            -38.55003527329329,
+            0.1649578149352564,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M18A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999924727858,
+            -0.00038800035879476777,
+            0.0
+          ],
+          "slow_axis": [
+            0.00038800035879476777,
+            0.999999924727858,
+            0.0
+          ],
+          "origin": [
+            -19.199988354691946,
+            0.15744998922301434,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M18A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999924727858,
+            -0.00038800035879476777,
+            0.0
+          ],
+          "slow_axis": [
+            0.00038800035879476777,
+            0.999999924727858,
+            0.0
+          ],
+          "origin": [
+            0.15005856390940875,
+            0.14994216351076872,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M18A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.999999924727858,
+            -0.00038800035879476777,
+            0.0
+          ],
+          "slow_axis": [
+            0.00038800035879476777,
+            0.999999924727858,
+            0.0
+          ],
+          "origin": [
+            19.500105482510758,
+            0.14243433779852666,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M19A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999977928935644,
+            0.0021010016658743764,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0021010016658743764,
+            0.9999977928935644,
+            0.0
+          ],
+          "origin": [
+            -38.509671958242016,
+            -19.280999440274492,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M19A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999977928935644,
+            0.0021010016658743764,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0021010016658743764,
+            0.9999977928935644,
+            0.0
+          ],
+          "origin": [
+            -19.15966629073738,
+            -19.240344956403614,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M19A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999977928935644,
+            0.0021010016658743764,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0021010016658743764,
+            0.9999977928935644,
+            0.0
+          ],
+          "origin": [
+            0.1903393767672599,
+            -19.199690472532737,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M19A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999977928935644,
+            0.0021010016658743764,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0021010016658743764,
+            0.9999977928935644,
+            0.0
+          ],
+          "origin": [
+            19.5403450442719,
+            -19.159035988661856,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M19A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999977928935644,
+            0.0021010016658743764,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0021010016658743764,
+            0.9999977928935644,
+            0.0
+          ],
+          "origin": [
+            -38.5503264421129,
+            0.06900622723014749,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M19A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999977928935644,
+            0.0021010016658743764,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0021010016658743764,
+            0.9999977928935644,
+            0.0
+          ],
+          "origin": [
+            -19.200320774608258,
+            0.10966071110102504,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M19A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999977928935644,
+            0.0021010016658743764,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0021010016658743764,
+            0.9999977928935644,
+            0.0
+          ],
+          "origin": [
+            0.14968489289638104,
+            0.1503151949719026,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M19A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999977928935644,
+            0.0021010016658743764,
+            0.0
+          ],
+          "slow_axis": [
+            -0.0021010016658743764,
+            0.9999977928935644,
+            0.0
+          ],
+          "origin": [
+            19.49969056040102,
+            0.1909696788427837,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M22A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999931956000794,
+            -0.0036890044106039775,
+            0.0
+          ],
+          "slow_axis": [
+            0.0036890044106039775,
+            0.9999931956000794,
+            0.0
+          ],
+          "origin": [
+            -38.62066312672448,
+            -19.05770587975744,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M22A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999931956000794,
+            -0.0036890044106039775,
+            0.0
+          ],
+          "slow_axis": [
+            0.0036890044106039775,
+            0.9999931956000794,
+            0.0
+          ],
+          "origin": [
+            -19.27074641707117,
+            -19.129088293558663,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M22A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999931956000794,
+            -0.0036890044106039775,
+            0.0
+          ],
+          "slow_axis": [
+            0.0036890044106039775,
+            0.9999931956000794,
+            0.0
+          ],
+          "origin": [
+            0.07917029258213923,
+            -19.200470707359884,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M22A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999931956000794,
+            -0.0036890044106039775,
+            0.0
+          ],
+          "slow_axis": [
+            0.0036890044106039775,
+            0.9999931956000794,
+            0.0
+          ],
+          "origin": [
+            19.429087002235452,
+            -19.271853121161104,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M22A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999931956000794,
+            -0.0036890044106039775,
+            0.0
+          ],
+          "slow_axis": [
+            0.0036890044106039775,
+            0.9999931956000794,
+            0.0
+          ],
+          "origin": [
+            -38.54928071292326,
+            0.2922108298958719,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M22A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999931956000794,
+            -0.0036890044106039775,
+            0.0
+          ],
+          "slow_axis": [
+            0.0036890044106039775,
+            0.9999931956000794,
+            0.0
+          ],
+          "origin": [
+            -19.199364003269945,
+            0.22082841609464765,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M22A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999931956000794,
+            -0.0036890044106039775,
+            0.0
+          ],
+          "slow_axis": [
+            0.0036890044106039775,
+            0.9999931956000794,
+            0.0
+          ],
+          "origin": [
+            0.1505527063833607,
+            0.14944600229342697,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M22A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999931956000794,
+            -0.0036890044106039775,
+            0.0
+          ],
+          "slow_axis": [
+            0.0036890044106039775,
+            0.9999931956000794,
+            0.0
+          ],
+          "origin": [
+            19.500469416036676,
+            0.07806358849220629,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M23A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997828591365,
+            -0.0006590005159046866,
+            0.0
+          ],
+          "slow_axis": [
+            0.0006590005159046866,
+            0.9999997828591365,
+            0.0
+          ],
+          "origin": [
+            -38.5627408459772,
+            -19.174639297605538,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M23A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997828591365,
+            -0.0006590005159046866,
+            0.0
+          ],
+          "slow_axis": [
+            0.0006590005159046866,
+            0.9999997828591365,
+            0.0
+          ],
+          "origin": [
+            -19.212696672542467,
+            -19.187390989467524,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M23A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997828591365,
+            -0.0006590005159046866,
+            0.0
+          ],
+          "slow_axis": [
+            0.0006590005159046866,
+            0.9999997828591365,
+            0.0
+          ],
+          "origin": [
+            0.13734750089225706,
+            -19.200142681329506,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M23A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997828591365,
+            -0.0006590005159046866,
+            0.0
+          ],
+          "slow_axis": [
+            0.0006590005159046866,
+            0.9999997828591365,
+            0.0
+          ],
+          "origin": [
+            19.487391674326982,
+            -19.212894373191492,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M23A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997828591365,
+            -0.0006590005159046866,
+            0.0
+          ],
+          "slow_axis": [
+            0.0006590005159046866,
+            0.9999997828591365,
+            0.0
+          ],
+          "origin": [
+            -38.54998915411522,
+            0.17540487582919084,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M23A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997828591365,
+            -0.0006590005159046866,
+            0.0
+          ],
+          "slow_axis": [
+            0.0006590005159046866,
+            0.9999997828591365,
+            0.0
+          ],
+          "origin": [
+            -19.19994498068048,
+            0.16265318396720474,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M23A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997828591365,
+            -0.0006590005159046866,
+            0.0
+          ],
+          "slow_axis": [
+            0.0006590005159046866,
+            0.9999997828591365,
+            0.0
+          ],
+          "origin": [
+            0.1500991927542424,
+            0.1499014921052222,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M23A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999997828591365,
+            -0.0006590005159046866,
+            0.0
+          ],
+          "slow_axis": [
+            0.0006590005159046866,
+            0.9999997828591365,
+            0.0
+          ],
+          "origin": [
+            19.50014336618897,
+            0.1371498002432361,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M26A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999774943389848,
+            -0.006709010025760868,
+            0.0
+          ],
+          "slow_axis": [
+            0.006709010025760868,
+            0.9999774943389848,
+            0.0
+          ],
+          "origin": [
+            -38.67804209436771,
+            -18.94098290727269,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M26A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999774943389848,
+            -0.006709010025760868,
+            0.0
+          ],
+          "slow_axis": [
+            0.006709010025760868,
+            0.9999774943389848,
+            0.0
+          ],
+          "origin": [
+            -19.32842920487613,
+            -19.070802575820334,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M26A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999774943389848,
+            -0.006709010025760868,
+            0.0
+          ],
+          "slow_axis": [
+            0.006709010025760868,
+            0.9999774943389848,
+            0.0
+          ],
+          "origin": [
+            0.021183684615450418,
+            -19.200622244367977,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M26A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999774943389848,
+            -0.006709010025760868,
+            0.0
+          ],
+          "slow_axis": [
+            0.006709010025760868,
+            0.9999774943389848,
+            0.0
+          ],
+          "origin": [
+            19.370796574107032,
+            -19.33044191291562,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M26A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999774943389848,
+            -0.006709010025760868,
+            0.0
+          ],
+          "slow_axis": [
+            0.006709010025760868,
+            0.9999774943389848,
+            0.0
+          ],
+          "origin": [
+            -38.54822242582007,
+            0.408629982218887,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M26A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999774943389848,
+            -0.006709010025760868,
+            0.0
+          ],
+          "slow_axis": [
+            0.006709010025760868,
+            0.9999774943389848,
+            0.0
+          ],
+          "origin": [
+            -19.198609536328487,
+            0.27881031367124365,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M26A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999774943389848,
+            -0.006709010025760868,
+            0.0
+          ],
+          "slow_axis": [
+            0.006709010025760868,
+            0.9999774943389848,
+            0.0
+          ],
+          "origin": [
+            0.15100335316309454,
+            0.14899064512360027,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M26A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999774943389848,
+            -0.006709010025760868,
+            0.0
+          ],
+          "slow_axis": [
+            0.006709010025760868,
+            0.9999774943389848,
+            0.0
+          ],
+          "origin": [
+            19.500616242654676,
+            0.0191709765759569,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M27A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999978388692168,
+            -0.0020790038230243937,
+            0.0
+          ],
+          "slow_axis": [
+            0.0020790038230243937,
+            0.9999978388692168,
+            0.0
+          ],
+          "origin": [
+            -38.58993003663547,
+            -19.119860708563145,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M27A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999978388692168,
+            -0.0020790038230243937,
+            0.0
+          ],
+          "slow_axis": [
+            0.0020790038230243937,
+            0.9999978388692168,
+            0.0
+          ],
+          "origin": [
+            -19.239923479499733,
+            -19.160089533110728,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M27A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999978388692168,
+            -0.0020790038230243937,
+            0.0
+          ],
+          "slow_axis": [
+            0.0020790038230243937,
+            0.9999978388692168,
+            0.0
+          ],
+          "origin": [
+            0.11008307763600902,
+            -19.20031835765831,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M27A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999978388692168,
+            -0.0020790038230243937,
+            0.0
+          ],
+          "slow_axis": [
+            0.0020790038230243937,
+            0.9999978388692168,
+            0.0
+          ],
+          "origin": [
+            19.460089634771744,
+            -19.240547182205894,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M27A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999978388692168,
+            -0.0020790038230243937,
+            0.0
+          ],
+          "slow_axis": [
+            0.0020790038230243937,
+            0.9999978388692168,
+            0.0
+          ],
+          "origin": [
+            -38.54970121208788,
+            0.2301458485725938,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M27A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999978388692168,
+            -0.0020790038230243937,
+            0.0
+          ],
+          "slow_axis": [
+            0.0020790038230243937,
+            0.9999978388692168,
+            0.0
+          ],
+          "origin": [
+            -19.19969465495215,
+            0.18991702402501076,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M27A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999978388692168,
+            -0.0020790038230243937,
+            0.0
+          ],
+          "slow_axis": [
+            0.0020790038230243937,
+            0.9999978388692168,
+            0.0
+          ],
+          "origin": [
+            0.15031190218359242,
+            0.14968819947742773,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M27A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999978388692168,
+            -0.0020790038230243937,
+            0.0
+          ],
+          "slow_axis": [
+            0.0020790038230243937,
+            0.9999978388692168,
+            0.0
+          ],
+          "origin": [
+            19.500318459319328,
+            0.1094593749298447,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M30A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999754576583726,
+            -0.0070060032064347185,
+            0.0
+          ],
+          "slow_axis": [
+            0.0070060032064347185,
+            0.9999754576583726,
+            0.0
+          ],
+          "origin": [
+            -38.68366586345847,
+            -18.929494687169413,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M30A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999754576583726,
+            -0.0070060032064347185,
+            0.0
+          ],
+          "slow_axis": [
+            0.0070060032064347185,
+            0.9999754576583726,
+            0.0
+          ],
+          "origin": [
+            -19.334092383835266,
+            -19.065061188130176,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M30A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999754576583726,
+            -0.0070060032064347185,
+            0.0
+          ],
+          "slow_axis": [
+            0.0070060032064347185,
+            0.9999754576583726,
+            0.0
+          ],
+          "origin": [
+            0.015481095787940935,
+            -19.200627689090943,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M30A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999754576583726,
+            -0.0070060032064347185,
+            0.0
+          ],
+          "slow_axis": [
+            0.0070060032064347185,
+            0.9999754576583726,
+            0.0
+          ],
+          "origin": [
+            19.36505457541115,
+            -19.336194190051707,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M30A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999754576583726,
+            -0.0070060032064347185,
+            0.0
+          ],
+          "slow_axis": [
+            0.0070060032064347185,
+            0.9999754576583726,
+            0.0
+          ],
+          "origin": [
+            -38.54809936249771,
+            0.4200787924537934,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M30A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999754576583726,
+            -0.0070060032064347185,
+            0.0
+          ],
+          "slow_axis": [
+            0.0070060032064347185,
+            0.9999754576583726,
+            0.0
+          ],
+          "origin": [
+            -19.198525882874502,
+            0.28451229149303003,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M30A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999754576583726,
+            -0.0070060032064347185,
+            0.0
+          ],
+          "slow_axis": [
+            0.0070060032064347185,
+            0.9999754576583726,
+            0.0
+          ],
+          "origin": [
+            0.15104759674870516,
+            0.1489457905322631,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M30A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999754576583726,
+            -0.0070060032064347185,
+            0.0
+          ],
+          "slow_axis": [
+            0.0070060032064347185,
+            0.9999754576583726,
+            0.0
+          ],
+          "origin": [
+            19.500621076371914,
+            0.013379289571499697,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M31A0",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999884894974643,
+            -0.004798007146701742,
+            0.0
+          ],
+          "slow_axis": [
+            0.004798007146701742,
+            0.9999884894974643,
+            0.0
+          ],
+          "origin": [
+            -38.64177461178045,
+            -19.014863360004362,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M31A1",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999884894974643,
+            -0.004798007146701742,
+            0.0
+          ],
+          "slow_axis": [
+            0.004798007146701742,
+            0.9999884894974643,
+            0.0
+          ],
+          "origin": [
+            -19.2919489654404,
+            -19.107705030397216,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M31A2",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999884894974643,
+            -0.004798007146701742,
+            0.0
+          ],
+          "slow_axis": [
+            0.004798007146701742,
+            0.9999884894974643,
+            0.0
+          ],
+          "origin": [
+            0.05787668089964482,
+            -19.20054670079007,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M31A3",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999884894974643,
+            -0.004798007146701742,
+            0.0
+          ],
+          "slow_axis": [
+            0.004798007146701742,
+            0.9999884894974643,
+            0.0
+          ],
+          "origin": [
+            19.407702327239697,
+            -19.293388371182925,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M31A4",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999884894974643,
+            -0.004798007146701742,
+            0.0
+          ],
+          "slow_axis": [
+            0.004798007146701742,
+            0.9999884894974643,
+            0.0
+          ],
+          "origin": [
+            -38.5489329413876,
+            0.3349622863356885,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M31A5",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999884894974643,
+            -0.004798007146701742,
+            0.0
+          ],
+          "slow_axis": [
+            0.004798007146701742,
+            0.9999884894974643,
+            0.0
+          ],
+          "origin": [
+            -19.199107295047547,
+            0.2421206159428344,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M31A6",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999884894974643,
+            -0.004798007146701742,
+            0.0
+          ],
+          "slow_axis": [
+            0.004798007146701742,
+            0.9999884894974643,
+            0.0
+          ],
+          "origin": [
+            0.1507183512924995,
+            0.14927894554998034,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        },
+        {
+          "name": "/entry/instrument/ELE_D0/ARRAY_D0Q3M31A7",
+          "type": "SENSOR_PAD",
+          "fast_axis": [
+            0.9999884894974643,
+            -0.004798007146701742,
+            0.0
+          ],
+          "slow_axis": [
+            0.004798007146701742,
+            0.9999884894974643,
+            0.0
+          ],
+          "origin": [
+            19.50054399763255,
+            0.056437275157126265,
+            676.2160109863282
+          ],
+          "raw_image_offset": [
+            0,
+            0
+          ],
+          "image_size": [
+            254,
+            254
+          ],
+          "pixel_size": [
+            0.07500018924474716,
+            0.07500018924474716
+          ],
+          "trusted_range": [
+            -2147483647.0,
+            2147483647.0
+          ],
+          "thickness": 0.32,
+          "material": "Si",
+          "mu": 26.564973172071888,
+          "identifier": "",
+          "mask": [],
+          "gain": 1.0,
+          "pedestal": 0.0,
+          "px_mm_strategy": {
+            "type": "ParallaxCorrectedPxMmStrategy"
+          }
+        }
+      ],
+      "hierarchy": {
+        "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0",
+        "type": "",
+        "fast_axis": [
+          0.9999968138532956,
+          -5.402479422213619e-05,
+          0.002523760008202826
+        ],
+        "slow_axis": [
+          6.25059388262594e-05,
+          0.999994351343886,
+          -0.003360561460261793
+        ],
+        "origin": [
+          1.7780006662265857,
+          -2.3817369843054195,
+          -796.1336963862889
+        ],
+        "raw_image_offset": [
+          0,
+          0
+        ],
+        "image_size": [
+          0,
+          0
+        ],
+        "pixel_size": [
+          0.0,
+          0.0
+        ],
+        "trusted_range": [
+          0.0,
+          0.0
+        ],
+        "thickness": 0.0,
+        "material": "",
+        "mu": 0.0,
+        "identifier": "",
+        "mask": [],
+        "gain": 1.0,
+        "pedestal": 0.0,
+        "px_mm_strategy": {
+          "type": "SimplePxMmStrategy"
+        },
+        "children": [
+          {
+            "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q0",
+            "type": "",
+            "fast_axis": [
+              0.9999969463036237,
+              1.3232515105752895e-09,
+              -0.0024713120862711836
+            ],
+            "slow_axis": [
+              -3.293971714450713e-06,
+              0.9999991124236038,
+              -0.0013323442326918747
+            ],
+            "origin": [
+              -76.75322627922202,
+              -85.54384800064079,
+              0.7208472911425307
+            ],
+            "raw_image_offset": [
+              0,
+              0
+            ],
+            "image_size": [
+              0,
+              0
+            ],
+            "pixel_size": [
+              0.0,
+              0.0
+            ],
+            "trusted_range": [
+              0.0,
+              0.0
+            ],
+            "thickness": 0.0,
+            "material": "",
+            "mu": 0.0,
+            "identifier": "",
+            "mask": [],
+            "gain": 1.0,
+            "pedestal": 0.0,
+            "px_mm_strategy": {
+              "type": "SimplePxMmStrategy"
+            },
+            "children": [
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q0M0",
+                "type": "",
+                "fast_axis": [
+                  1.0,
+                  -6.485096002415737e-22,
+                  3.3881317890172014e-21
+                ],
+                "slow_axis": [
+                  -2.3161057151484775e-21,
+                  1.0,
+                  0.0
+                ],
+                "origin": [
+                  -38.31071430374119,
+                  -61.113781401191346,
+                  -6.123990203832363e-13
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 0
+                  },
+                  {
+                    "panel": 1
+                  },
+                  {
+                    "panel": 2
+                  },
+                  {
+                    "panel": 3
+                  },
+                  {
+                    "panel": 4
+                  },
+                  {
+                    "panel": 5
+                  },
+                  {
+                    "panel": 6
+                  },
+                  {
+                    "panel": 7
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q0M12",
+                "type": "",
+                "fast_axis": [
+                  0.9999994283288534,
+                  -0.0008607534990528355,
+                  0.0006343858293896456
+                ],
+                "slow_axis": [
+                  0.0008605606262061709,
+                  0.9999995834362926,
+                  0.0003042411049143109
+                ],
+                "origin": [
+                  -39.062044424745835,
+                  61.511102042966726,
+                  -0.34822025137192797
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 8
+                  },
+                  {
+                    "panel": 9
+                  },
+                  {
+                    "panel": 10
+                  },
+                  {
+                    "panel": 11
+                  },
+                  {
+                    "panel": 12
+                  },
+                  {
+                    "panel": 13
+                  },
+                  {
+                    "panel": 14
+                  },
+                  {
+                    "panel": 15
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q0M13",
+                "type": "",
+                "fast_axis": [
+                  0.9999978967238913,
+                  0.0005655589918159485,
+                  0.001971469203551225
+                ],
+                "slow_axis": [
+                  -0.0005681570744235838,
+                  0.9999989706556215,
+                  0.0013175299754747218
+                ],
+                "origin": [
+                  39.950273461584636,
+                  62.26923579301318,
+                  0.044049773629434935
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 16
+                  },
+                  {
+                    "panel": 17
+                  },
+                  {
+                    "panel": 18
+                  },
+                  {
+                    "panel": 19
+                  },
+                  {
+                    "panel": 20
+                  },
+                  {
+                    "panel": 21
+                  },
+                  {
+                    "panel": 22
+                  },
+                  {
+                    "panel": 23
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q0M1",
+                "type": "",
+                "fast_axis": [
+                  1.0,
+                  -6.485096002415737e-22,
+                  3.3881317890172014e-21
+                ],
+                "slow_axis": [
+                  -2.3161057151484775e-21,
+                  1.0,
+                  0.0
+                ],
+                "origin": [
+                  38.9579317627143,
+                  -61.27917713364081,
+                  -1.066813304362313e-12
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 24
+                  },
+                  {
+                    "panel": 25
+                  },
+                  {
+                    "panel": 26
+                  },
+                  {
+                    "panel": 27
+                  },
+                  {
+                    "panel": 28
+                  },
+                  {
+                    "panel": 29
+                  },
+                  {
+                    "panel": 30
+                  },
+                  {
+                    "panel": 31
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q0M4",
+                "type": "",
+                "fast_axis": [
+                  1.0,
+                  -6.485096002415737e-22,
+                  3.3881317890172014e-21
+                ],
+                "slow_axis": [
+                  -2.3161057151484775e-21,
+                  1.0,
+                  0.0
+                ],
+                "origin": [
+                  -38.70238479470787,
+                  -20.488801389199217,
+                  -7.478601071753133e-13
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 32
+                  },
+                  {
+                    "panel": 33
+                  },
+                  {
+                    "panel": 34
+                  },
+                  {
+                    "panel": 35
+                  },
+                  {
+                    "panel": 36
+                  },
+                  {
+                    "panel": 37
+                  },
+                  {
+                    "panel": 38
+                  },
+                  {
+                    "panel": 39
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q0M5",
+                "type": "",
+                "fast_axis": [
+                  1.0,
+                  -6.485096002415737e-22,
+                  3.3881317890172014e-21
+                ],
+                "slow_axis": [
+                  -2.3161057151484775e-21,
+                  1.0,
+                  0.0
+                ],
+                "origin": [
+                  38.981636396519065,
+                  -20.481108096203787,
+                  -7.348288644237755e-13
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 40
+                  },
+                  {
+                    "panel": 41
+                  },
+                  {
+                    "panel": 42
+                  },
+                  {
+                    "panel": 43
+                  },
+                  {
+                    "panel": 44
+                  },
+                  {
+                    "panel": 45
+                  },
+                  {
+                    "panel": 46
+                  },
+                  {
+                    "panel": 47
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q0M8",
+                "type": "",
+                "fast_axis": [
+                  0.9999999651312089,
+                  0.00025315256950728565,
+                  7.517551182975893e-05
+                ],
+                "slow_axis": [
+                  -0.0002531680126533445,
+                  0.9999999468400166,
+                  0.0002054894686680416
+                ],
+                "origin": [
+                  -38.9557659704819,
+                  20.459515183819683,
+                  0.16159637178587027
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 48
+                  },
+                  {
+                    "panel": 49
+                  },
+                  {
+                    "panel": 50
+                  },
+                  {
+                    "panel": 51
+                  },
+                  {
+                    "panel": 52
+                  },
+                  {
+                    "panel": 53
+                  },
+                  {
+                    "panel": 54
+                  },
+                  {
+                    "panel": 55
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q0M9",
+                "type": "",
+                "fast_axis": [
+                  0.9999992212574192,
+                  0.000878545342099036,
+                  0.0008863648442024316
+                ],
+                "slow_axis": [
+                  -0.0008798224040159324,
+                  0.9999985741005561,
+                  0.0014414261659842125
+                ],
+                "origin": [
+                  39.25763332248983,
+                  21.181825310051465,
+                  -0.021252022443281768
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 56
+                  },
+                  {
+                    "panel": 57
+                  },
+                  {
+                    "panel": 58
+                  },
+                  {
+                    "panel": 59
+                  },
+                  {
+                    "panel": 60
+                  },
+                  {
+                    "panel": 61
+                  },
+                  {
+                    "panel": 62
+                  },
+                  {
+                    "panel": 63
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q1",
+            "type": "",
+            "fast_axis": [
+              0.9999994731840274,
+              0.00010854973615996031,
+              -0.0010207098621657872
+            ],
+            "slow_axis": [
+              -0.00010958688631772392,
+              0.9999994777598183,
+              -0.001016105705567212
+            ],
+            "origin": [
+              79.51257465018791,
+              -80.1056658103924,
+              0.5657183449801093
+            ],
+            "raw_image_offset": [
+              0,
+              0
+            ],
+            "image_size": [
+              0,
+              0
+            ],
+            "pixel_size": [
+              0.0,
+              0.0
+            ],
+            "trusted_range": [
+              0.0,
+              0.0
+            ],
+            "thickness": 0.0,
+            "material": "",
+            "mu": 0.0,
+            "identifier": "",
+            "mask": [],
+            "gain": 1.0,
+            "pedestal": 0.0,
+            "px_mm_strategy": {
+              "type": "SimplePxMmStrategy"
+            },
+            "children": [
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q1M10",
+                "type": "",
+                "fast_axis": [
+                  0.9999997226971175,
+                  -0.0005752996188012881,
+                  -0.0004729017203229651
+                ],
+                "slow_axis": [
+                  0.0005761851071876371,
+                  0.9999980772056153,
+                  0.0018744588005071053
+                ],
+                "origin": [
+                  -38.97925950053379,
+                  21.338086954077422,
+                  -0.08081161831621667
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 64
+                  },
+                  {
+                    "panel": 65
+                  },
+                  {
+                    "panel": 66
+                  },
+                  {
+                    "panel": 67
+                  },
+                  {
+                    "panel": 68
+                  },
+                  {
+                    "panel": 69
+                  },
+                  {
+                    "panel": 70
+                  },
+                  {
+                    "panel": 71
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q1M11",
+                "type": "",
+                "fast_axis": [
+                  0.9999997218610741,
+                  -0.0007455032272483715,
+                  -2.242125137868404e-05
+                ],
+                "slow_axis": [
+                  0.0007455138232632443,
+                  0.9999996086487919,
+                  0.0004763521833202859
+                ],
+                "origin": [
+                  39.25546773914491,
+                  20.615373720054016,
+                  -0.2600677223905403
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 72
+                  },
+                  {
+                    "panel": 73
+                  },
+                  {
+                    "panel": 74
+                  },
+                  {
+                    "panel": 75
+                  },
+                  {
+                    "panel": 76
+                  },
+                  {
+                    "panel": 77
+                  },
+                  {
+                    "panel": 78
+                  },
+                  {
+                    "panel": 79
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q1M14",
+                "type": "",
+                "fast_axis": [
+                  0.9999995165626603,
+                  -0.0002734601675237728,
+                  -0.0009445072697249528
+                ],
+                "slow_axis": [
+                  0.00027410426535270043,
+                  0.9999997299542718,
+                  0.0006818784609549717
+                ],
+                "origin": [
+                  -39.458985745075644,
+                  61.833354084586766,
+                  0.03662329313818047
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 80
+                  },
+                  {
+                    "panel": 81
+                  },
+                  {
+                    "panel": 82
+                  },
+                  {
+                    "panel": 83
+                  },
+                  {
+                    "panel": 84
+                  },
+                  {
+                    "panel": 85
+                  },
+                  {
+                    "panel": 86
+                  },
+                  {
+                    "panel": 87
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q1M15",
+                "type": "",
+                "fast_axis": [
+                  0.9999972344109043,
+                  -0.002291295562032169,
+                  -0.0005302218315306117
+                ],
+                "slow_axis": [
+                  0.0022917834766968443,
+                  0.9999969493356653,
+                  0.0009214379300882304
+                ],
+                "origin": [
+                  39.0002692132511,
+                  61.98978527434225,
+                  -0.19608304779714747
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 88
+                  },
+                  {
+                    "panel": 89
+                  },
+                  {
+                    "panel": 90
+                  },
+                  {
+                    "panel": 91
+                  },
+                  {
+                    "panel": 92
+                  },
+                  {
+                    "panel": 93
+                  },
+                  {
+                    "panel": 94
+                  },
+                  {
+                    "panel": 95
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q1M2",
+                "type": "",
+                "fast_axis": [
+                  1.0,
+                  -2.964615315390051e-20,
+                  -6.505213034913027e-19
+                ],
+                "slow_axis": [
+                  3.642241673193492e-20,
+                  1.0,
+                  -8.673617379884037e-19
+                ],
+                "origin": [
+                  -38.77384182669935,
+                  -61.435594464521174,
+                  -3.4619529465373944e-13
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 96
+                  },
+                  {
+                    "panel": 97
+                  },
+                  {
+                    "panel": 98
+                  },
+                  {
+                    "panel": 99
+                  },
+                  {
+                    "panel": 100
+                  },
+                  {
+                    "panel": 101
+                  },
+                  {
+                    "panel": 102
+                  },
+                  {
+                    "panel": 103
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q1M3",
+                "type": "",
+                "fast_axis": [
+                  1.0,
+                  -2.964615315390051e-20,
+                  -6.505213034913027e-19
+                ],
+                "slow_axis": [
+                  3.642241673193492e-20,
+                  1.0,
+                  -8.673617379884037e-19
+                ],
+                "origin": [
+                  38.43179845699689,
+                  -60.862556350998624,
+                  -2.8044233602031454e-13
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 104
+                  },
+                  {
+                    "panel": 105
+                  },
+                  {
+                    "panel": 106
+                  },
+                  {
+                    "panel": 107
+                  },
+                  {
+                    "panel": 108
+                  },
+                  {
+                    "panel": 109
+                  },
+                  {
+                    "panel": 110
+                  },
+                  {
+                    "panel": 111
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q1M6",
+                "type": "",
+                "fast_axis": [
+                  0.9999997565261679,
+                  -0.0006659070583450452,
+                  0.00020860343875348094
+                ],
+                "slow_axis": [
+                  0.0006657657990209284,
+                  0.9999995495477189,
+                  0.0006765059203099476
+                ],
+                "origin": [
+                  -38.5773800336312,
+                  -20.743874264584772,
+                  -0.30640180572046616
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 112
+                  },
+                  {
+                    "panel": 113
+                  },
+                  {
+                    "panel": 114
+                  },
+                  {
+                    "panel": 115
+                  },
+                  {
+                    "panel": 116
+                  },
+                  {
+                    "panel": 117
+                  },
+                  {
+                    "panel": 118
+                  },
+                  {
+                    "panel": 119
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q1M7",
+                "type": "",
+                "fast_axis": [
+                  1.0,
+                  -2.964615315390051e-20,
+                  -6.505213034913027e-19
+                ],
+                "slow_axis": [
+                  3.642241673193492e-20,
+                  1.0,
+                  -8.673617379884037e-19
+                ],
+                "origin": [
+                  38.64249771291152,
+                  -20.37282390717561,
+                  -4.764522110178859e-13
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 120
+                  },
+                  {
+                    "panel": 121
+                  },
+                  {
+                    "panel": 122
+                  },
+                  {
+                    "panel": 123
+                  },
+                  {
+                    "panel": 124
+                  },
+                  {
+                    "panel": 125
+                  },
+                  {
+                    "panel": 126
+                  },
+                  {
+                    "panel": 127
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q2",
+            "type": "",
+            "fast_axis": [
+              0.9999978069650278,
+              0.001406286698860097,
+              -0.0015519094225729538
+            ],
+            "slow_axis": [
+              -0.0014055992391185236,
+              0.9999989135863327,
+              0.000443978527838416
+            ],
+            "origin": [
+              -81.36800905734194,
+              79.7843073347859,
+              0.6807367182065719
+            ],
+            "raw_image_offset": [
+              0,
+              0
+            ],
+            "image_size": [
+              0,
+              0
+            ],
+            "pixel_size": [
+              0.0,
+              0.0
+            ],
+            "trusted_range": [
+              0.0,
+              0.0
+            ],
+            "thickness": 0.0,
+            "material": "",
+            "mu": 0.0,
+            "identifier": "",
+            "mask": [],
+            "gain": 1.0,
+            "pedestal": 0.0,
+            "px_mm_strategy": {
+              "type": "SimplePxMmStrategy"
+            },
+            "children": [
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q2M16",
+                "type": "",
+                "fast_axis": [
+                  0.9999991488801555,
+                  -0.0012056564601916275,
+                  0.0004986295866695123
+                ],
+                "slow_axis": [
+                  0.0012060373080992357,
+                  0.9999989807393854,
+                  -0.0007641951333290065
+                ],
+                "origin": [
+                  -38.87998852230543,
+                  -62.02120260880546,
+                  -0.034691324206630736
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 128
+                  },
+                  {
+                    "panel": 129
+                  },
+                  {
+                    "panel": 130
+                  },
+                  {
+                    "panel": 131
+                  },
+                  {
+                    "panel": 132
+                  },
+                  {
+                    "panel": 133
+                  },
+                  {
+                    "panel": 134
+                  },
+                  {
+                    "panel": 135
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q2M17",
+                "type": "",
+                "fast_axis": [
+                  0.9999989007672072,
+                  -0.0006541659149932324,
+                  0.0013306131418217091
+                ],
+                "slow_axis": [
+                  0.0006575582987556551,
+                  0.9999965308911418,
+                  -0.002550651439457032
+                ],
+                "origin": [
+                  39.46935457799326,
+                  -63.27884573640071,
+                  0.061258666811149276
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 136
+                  },
+                  {
+                    "panel": 137
+                  },
+                  {
+                    "panel": 138
+                  },
+                  {
+                    "panel": 139
+                  },
+                  {
+                    "panel": 140
+                  },
+                  {
+                    "panel": 141
+                  },
+                  {
+                    "panel": 142
+                  },
+                  {
+                    "panel": 143
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q2M20",
+                "type": "",
+                "fast_axis": [
+                  0.9999999910901652,
+                  -0.00010605509113214084,
+                  8.106779285816451e-05
+                ],
+                "slow_axis": [
+                  0.00010606824964825526,
+                  0.9999999811995888,
+                  -0.00016232790457521715
+                ],
+                "origin": [
+                  -39.204648714569224,
+                  -20.420706274833734,
+                  -0.10843864363639807
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 144
+                  },
+                  {
+                    "panel": 145
+                  },
+                  {
+                    "panel": 146
+                  },
+                  {
+                    "panel": 147
+                  },
+                  {
+                    "panel": 148
+                  },
+                  {
+                    "panel": 149
+                  },
+                  {
+                    "panel": 150
+                  },
+                  {
+                    "panel": 151
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q2M21",
+                "type": "",
+                "fast_axis": [
+                  0.9999992716882457,
+                  0.00019460939069823404,
+                  0.0011911129935344715
+                ],
+                "slow_axis": [
+                  -0.00019298738751765738,
+                  0.9999990542398989,
+                  -0.0013617177300281125
+                ],
+                "origin": [
+                  39.39020124920366,
+                  -21.25768314688265,
+                  -0.0047206208822149626
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 152
+                  },
+                  {
+                    "panel": 153
+                  },
+                  {
+                    "panel": 154
+                  },
+                  {
+                    "panel": 155
+                  },
+                  {
+                    "panel": 156
+                  },
+                  {
+                    "panel": 157
+                  },
+                  {
+                    "panel": 158
+                  },
+                  {
+                    "panel": 159
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q2M24",
+                "type": "",
+                "fast_axis": [
+                  1.0,
+                  -2.473336205982557e-19,
+                  2.168404344971009e-19
+                ],
+                "slow_axis": [
+                  1.8634724839594612e-19,
+                  1.0,
+                  -4.336808689942019e-19
+                ],
+                "origin": [
+                  -38.72577959376528,
+                  20.60871921365771,
+                  -5.547506898295751e-13
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 160
+                  },
+                  {
+                    "panel": 161
+                  },
+                  {
+                    "panel": 162
+                  },
+                  {
+                    "panel": 163
+                  },
+                  {
+                    "panel": 164
+                  },
+                  {
+                    "panel": 165
+                  },
+                  {
+                    "panel": 166
+                  },
+                  {
+                    "panel": 167
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q2M25",
+                "type": "",
+                "fast_axis": [
+                  0.999999407671603,
+                  0.001057601977300167,
+                  0.0002571662902163698
+                ],
+                "slow_axis": [
+                  -0.001057319994046619,
+                  0.9999988424255669,
+                  -0.001094176382757475
+                ],
+                "origin": [
+                  38.85622373588612,
+                  20.22427782092949,
+                  -0.10327663499231268
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 168
+                  },
+                  {
+                    "panel": 169
+                  },
+                  {
+                    "panel": 170
+                  },
+                  {
+                    "panel": 171
+                  },
+                  {
+                    "panel": 172
+                  },
+                  {
+                    "panel": 173
+                  },
+                  {
+                    "panel": 174
+                  },
+                  {
+                    "panel": 175
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q2M28",
+                "type": "",
+                "fast_axis": [
+                  1.0,
+                  -2.473336205982557e-19,
+                  2.168404344971009e-19
+                ],
+                "slow_axis": [
+                  1.8634724839594612e-19,
+                  1.0,
+                  -4.336808689942019e-19
+                ],
+                "origin": [
+                  -38.33092655905333,
+                  61.16469181555834,
+                  -5.543343561953407e-13
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 176
+                  },
+                  {
+                    "panel": 177
+                  },
+                  {
+                    "panel": 178
+                  },
+                  {
+                    "panel": 179
+                  },
+                  {
+                    "panel": 180
+                  },
+                  {
+                    "panel": 181
+                  },
+                  {
+                    "panel": 182
+                  },
+                  {
+                    "panel": 183
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q2M29",
+                "type": "",
+                "fast_axis": [
+                  1.0,
+                  -2.473336205982557e-19,
+                  2.168404344971009e-19
+                ],
+                "slow_axis": [
+                  1.8634724839594612e-19,
+                  1.0,
+                  -4.336808689942019e-19
+                ],
+                "origin": [
+                  39.09185514650717,
+                  61.486500430848025,
+                  -3.6903813338540203e-13
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 184
+                  },
+                  {
+                    "panel": 185
+                  },
+                  {
+                    "panel": 186
+                  },
+                  {
+                    "panel": 187
+                  },
+                  {
+                    "panel": 188
+                  },
+                  {
+                    "panel": 189
+                  },
+                  {
+                    "panel": 190
+                  },
+                  {
+                    "panel": 191
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q3",
+            "type": "",
+            "fast_axis": [
+              0.9999993410926352,
+              0.001139356727478521,
+              0.0001402873585895433
+            ],
+            "slow_axis": [
+              -0.0011393482689559344,
+              0.9999993491209193,
+              -6.03594235287432e-05
+            ],
+            "origin": [
+              75.1379815913745,
+              84.50880274248978,
+              0.5572450561500887
+            ],
+            "raw_image_offset": [
+              0,
+              0
+            ],
+            "image_size": [
+              0,
+              0
+            ],
+            "pixel_size": [
+              0.0,
+              0.0
+            ],
+            "trusted_range": [
+              0.0,
+              0.0
+            ],
+            "thickness": 0.0,
+            "material": "",
+            "mu": 0.0,
+            "identifier": "",
+            "mask": [],
+            "gain": 1.0,
+            "pedestal": 0.0,
+            "px_mm_strategy": {
+              "type": "SimplePxMmStrategy"
+            },
+            "children": [
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q3M18",
+                "type": "",
+                "fast_axis": [
+                  0.999997997631125,
+                  0.00034528360252467636,
+                  -0.0019711704579823833
+                ],
+                "slow_axis": [
+                  -0.00034950797745077645,
+                  0.9999976424003584,
+                  -0.0021431373961571785
+                ],
+                "origin": [
+                  -40.18276410556323,
+                  -62.85745489476529,
+                  0.04562442755450859
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 192
+                  },
+                  {
+                    "panel": 193
+                  },
+                  {
+                    "panel": 194
+                  },
+                  {
+                    "panel": 195
+                  },
+                  {
+                    "panel": 196
+                  },
+                  {
+                    "panel": 197
+                  },
+                  {
+                    "panel": 198
+                  },
+                  {
+                    "panel": 199
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q3M19",
+                "type": "",
+                "fast_axis": [
+                  0.9999991041051899,
+                  -0.0009168768533238798,
+                  -0.0009752567115761726
+                ],
+                "slow_axis": [
+                  0.0009169358800860647,
+                  0.9999995778094679,
+                  6.007893113705796e-05
+                ],
+                "origin": [
+                  38.5311898837803,
+                  -61.33371335429421,
+                  -0.3090183675361211
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 200
+                  },
+                  {
+                    "panel": 201
+                  },
+                  {
+                    "panel": 202
+                  },
+                  {
+                    "panel": 203
+                  },
+                  {
+                    "panel": 204
+                  },
+                  {
+                    "panel": 205
+                  },
+                  {
+                    "panel": 206
+                  },
+                  {
+                    "panel": 207
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q3M22",
+                "type": "",
+                "fast_axis": [
+                  0.999994974563542,
+                  0.002525680107966584,
+                  -0.0019161909229690587
+                ],
+                "slow_axis": [
+                  -0.0025280053045118093,
+                  0.9999960701183847,
+                  -0.001211997098612402
+                ],
+                "origin": [
+                  -40.09399110917123,
+                  -20.96651068209977,
+                  0.0058760136210520425
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 208
+                  },
+                  {
+                    "panel": 209
+                  },
+                  {
+                    "panel": 210
+                  },
+                  {
+                    "panel": 211
+                  },
+                  {
+                    "panel": 212
+                  },
+                  {
+                    "panel": 213
+                  },
+                  {
+                    "panel": 214
+                  },
+                  {
+                    "panel": 215
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q3M23",
+                "type": "",
+                "fast_axis": [
+                  0.9999999965557108,
+                  1.061181740467416e-05,
+                  -8.231626652592139e-05
+                ],
+                "slow_axis": [
+                  -1.0620729430179649e-05,
+                  0.9999999940828382,
+                  -0.00010826598548019896
+                ],
+                "origin": [
+                  38.87280579797506,
+                  -20.434310884559313,
+                  0.03806487774032247
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 216
+                  },
+                  {
+                    "panel": 217
+                  },
+                  {
+                    "panel": 218
+                  },
+                  {
+                    "panel": 219
+                  },
+                  {
+                    "panel": 220
+                  },
+                  {
+                    "panel": 221
+                  },
+                  {
+                    "panel": 222
+                  },
+                  {
+                    "panel": 223
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q3M26",
+                "type": "",
+                "fast_axis": [
+                  0.9999999817664987,
+                  0.0001471574578119946,
+                  0.00012170326636800962
+                ],
+                "slow_axis": [
+                  -0.00014714360663011742,
+                  0.9999999826977689,
+                  -0.0001138122178773438
+                ],
+                "origin": [
+                  -38.735652769011445,
+                  20.859188925129175,
+                  -0.06061373348601781
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 224
+                  },
+                  {
+                    "panel": 225
+                  },
+                  {
+                    "panel": 226
+                  },
+                  {
+                    "panel": 227
+                  },
+                  {
+                    "panel": 228
+                  },
+                  {
+                    "panel": 229
+                  },
+                  {
+                    "panel": 230
+                  },
+                  {
+                    "panel": 231
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q3M27",
+                "type": "",
+                "fast_axis": [
+                  1.0,
+                  7.623296525288704e-20,
+                  -4.336808689942019e-19
+                ],
+                "slow_axis": [
+                  7.962109704190424e-20,
+                  1.0,
+                  -8.673617379884037e-19
+                ],
+                "origin": [
+                  38.7697676492522,
+                  20.425615529782185,
+                  1.7343071423425727e-13
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 232
+                  },
+                  {
+                    "panel": 233
+                  },
+                  {
+                    "panel": 234
+                  },
+                  {
+                    "panel": 235
+                  },
+                  {
+                    "panel": 236
+                  },
+                  {
+                    "panel": 237
+                  },
+                  {
+                    "panel": 238
+                  },
+                  {
+                    "panel": 239
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q3M30",
+                "type": "",
+                "fast_axis": [
+                  1.0,
+                  7.623296525288704e-20,
+                  -4.336808689942019e-19
+                ],
+                "slow_axis": [
+                  7.962109704190424e-20,
+                  1.0,
+                  -8.673617379884037e-19
+                ],
+                "origin": [
+                  -38.67187751601414,
+                  61.39798121167302,
+                  -1.0536016503692736e-13
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 240
+                  },
+                  {
+                    "panel": 241
+                  },
+                  {
+                    "panel": 242
+                  },
+                  {
+                    "panel": 243
+                  },
+                  {
+                    "panel": 244
+                  },
+                  {
+                    "panel": 245
+                  },
+                  {
+                    "panel": 246
+                  },
+                  {
+                    "panel": 247
+                  }
+                ]
+              },
+              {
+                "name": "/entry/instrument/ELE_D0/transformations/AXIS_D0Q3M31",
+                "type": "",
+                "fast_axis": [
+                  1.0,
+                  7.623296525288704e-20,
+                  -4.336808689942019e-19
+                ],
+                "slow_axis": [
+                  7.962109704190424e-20,
+                  1.0,
+                  -8.673617379884037e-19
+                ],
+                "origin": [
+                  38.52781471394992,
+                  60.877514947012855,
+                  6.647460359943125e-15
+                ],
+                "raw_image_offset": [
+                  0,
+                  0
+                ],
+                "image_size": [
+                  0,
+                  0
+                ],
+                "pixel_size": [
+                  0.0,
+                  0.0
+                ],
+                "trusted_range": [
+                  0.0,
+                  0.0
+                ],
+                "thickness": 0.0,
+                "material": "",
+                "mu": 0.0,
+                "identifier": "",
+                "mask": [],
+                "gain": 1.0,
+                "pedestal": 0.0,
+                "px_mm_strategy": {
+                  "type": "SimplePxMmStrategy"
+                },
+                "children": [
+                  {
+                    "panel": 248
+                  },
+                  {
+                    "panel": 249
+                  },
+                  {
+                    "panel": 250
+                  },
+                  {
+                    "panel": 251
+                  },
+                  {
+                    "panel": 252
+                  },
+                  {
+                    "panel": 253
+                  },
+                  {
+                    "panel": 254
+                  },
+                  {
+                    "panel": 255
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "goniometer": [],
+  "scan": [],
+  "crystal": [
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        65.04409623611136,
+        -4.814086350212177,
+        -97.94124063128626
+      ],
+      "real_space_b": [
+        -164.95036564485147,
+        -106.91833082283839,
+        -104.29042264879094
+      ],
+      "real_space_c": [
+        -118.20134622359713,
+        271.96651422581164,
+        -91.86702113287971
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.12144948563346722,
+      "ML_domain_size_ang": 1813.5447176079701
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        71.61811134818733,
+        -56.3377804097553,
+        96.90246161798272
+      ],
+      "real_space_b": [
+        172.93551473134679,
+        141.28497686321455,
+        -45.67100643754196
+      ],
+      "real_space_c": [
+        -104.23841772334764,
+        187.78481071589283,
+        186.21547622604808
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.0008502179159367426,
+      "ML_domain_size_ang": 861.2596193229372
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        95.81769962935194,
+        -55.659871665279624,
+        -38.82217407503529
+      ],
+      "real_space_b": [
+        122.48834424764945,
+        180.22034855374412,
+        43.93133424079176
+      ],
+      "real_space_c": [
+        53.66204805108875,
+        -105.69698030019042,
+        283.98343532390743
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.12880053897566282,
+      "ML_domain_size_ang": 4843.745365562942
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -54.944059106282154,
+        -14.924744845255342,
+        103.04449376901378
+      ],
+      "real_space_b": [
+        -190.23602256816912,
+        71.80478205404486,
+        -91.03515262379358
+      ],
+      "real_space_c": [
+        -71.25490039545386,
+        -290.2450554041119,
+        -80.03209634791114
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 2.32398170505163e-06,
+      "ML_domain_size_ang": 1317.0862505300204
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -23.451346115051628,
+        61.61195700887321,
+        -97.37975732203013
+      ],
+      "real_space_b": [
+        99.59302017021719,
+        178.68536190575998,
+        89.06948104742662
+      ],
+      "real_space_c": [
+        270.5988979486085,
+        -89.96535603980898,
+        -122.087489122007
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.030195465155174874,
+      "ML_domain_size_ang": 16041.066078798005
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        112.96658553815725,
+        -21.64204597441065,
+        24.21946562847968
+      ],
+      "real_space_b": [
+        -27.99638369884355,
+        83.436028056157,
+        205.14004335197728
+      ],
+      "real_space_c": [
+        -76.47701218822851,
+        -282.3547145963467,
+        104.40417073880744
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 9.497933674248619e-05,
+      "ML_domain_size_ang": 1748.933131111537
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -84.33758583595568,
+        -75.56747805774579,
+        -31.395725757448705
+      ],
+      "real_space_b": [
+        -112.34100559351364,
+        165.44845196186486,
+        -96.4447544410499
+      ],
+      "real_space_c": [
+        147.74902679278176,
+        -54.52959647342322,
+        -265.6454642502819
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.026010180856318073,
+      "ML_domain_size_ang": 3798.242039687171
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        19.235953904007886,
+        119.97699573570269,
+        -51.86430367217169
+      ],
+      "real_space_b": [
+        -75.99760599539881,
+        95.04656716243693,
+        191.68318927479703
+      ],
+      "real_space_c": [
+        263.8830060139885,
+        2.403388981180514,
+        103.43130726655787
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 1.9880455717438883e-07,
+      "ML_domain_size_ang": 2414.774053355897
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        50.59955556508495,
+        -2.8725265547444536,
+        105.90268918786681
+      ],
+      "real_space_b": [
+        135.60309816228113,
+        166.1891406135119,
+        -60.282452029263105
+      ],
+      "real_space_c": [
+        -206.48476969921248,
+        206.29855567614698,
+        104.25264685714077
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.10795530794304112,
+      "ML_domain_size_ang": 2633.842614597702
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -26.2422593968153,
+        110.92676534983619,
+        28.249902225349828
+      ],
+      "real_space_b": [
+        -214.8922358411841,
+        -39.77450733367472,
+        -43.440870825275724
+      ],
+      "real_space_c": [
+        -43.66506217876768,
+        -85.20795335842077,
+        294.0177524721748
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 1.6303194006612304e-07,
+      "ML_domain_size_ang": 4774.037067126457
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -1.220252453547896,
+        -53.62241114591052,
+        -104.58670573812498
+      ],
+      "real_space_b": [
+        -218.57836639651333,
+        38.557078968991014,
+        -17.218275883760736
+      ],
+      "real_space_c": [
+        58.58396380052317,
+        269.9886491178897,
+        -139.10878510432983
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.015507544962880732,
+      "ML_domain_size_ang": 8214.215419345292
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        42.24099777405505,
+        -77.93148985279377,
+        -76.95321867180735
+      ],
+      "real_space_b": [
+        -196.2380399400962,
+        -1.9621843909218832,
+        -105.7314404228414
+      ],
+      "real_space_c": [
+        95.32561703224845,
+        230.59871857887305,
+        -181.20427918157617
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.4274687367121595,
+      "ML_domain_size_ang": 2650.9468593595625
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -40.62963771721779,
+        42.99991970965349,
+        101.78802615217147
+      ],
+      "real_space_b": [
+        -135.63016374405933,
+        -174.9416295232659,
+        19.765307207358404
+      ],
+      "real_space_c": [
+        220.5041644866783,
+        -153.67522423429992,
+        152.93573527397976
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.0003162294001202971,
+      "ML_domain_size_ang": 2854.4136674909987
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -80.12563305436056,
+        59.744675119168086,
+        -61.71106447315018
+      ],
+      "real_space_b": [
+        102.08401913578898,
+        190.68904287321106,
+        52.06697185809458
+      ],
+      "real_space_c": [
+        176.43104447173295,
+        -25.232136961218195,
+        -253.50615951304127
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 5.227424451272429e-06,
+      "ML_domain_size_ang": 2807.4354054244873
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        30.491167636460965,
+        -88.44767937145869,
+        70.97896285154239
+      ],
+      "real_space_b": [
+        214.07334521276886,
+        58.43519525597874,
+        -19.144952064365054
+      ],
+      "real_space_c": [
+        -29.07058411513422,
+        186.88868528887494,
+        245.37223239730395
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 8.763811161702713e-05,
+      "ML_domain_size_ang": 2014.1694877566365
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -65.02527420271844,
+        87.28047461242006,
+        -44.25194417406684
+      ],
+      "real_space_b": [
+        183.42188935834466,
+        118.50349927776992,
+        -35.79542141425269
+      ],
+      "real_space_c": [
+        25.078626284275256,
+        -123.56571741462727,
+        -280.5666337211762
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.07211789436296477,
+      "ML_domain_size_ang": 3496.8177624442856
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        14.532651654531232,
+        18.726608686055087,
+        114.8242837131891
+      ],
+      "real_space_b": [
+        -61.491727678411785,
+        211.24442833867423,
+        -26.669044121982726
+      ],
+      "real_space_c": [
+        -293.1570973884372,
+        -79.024647950594,
+        49.99128624622401
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 3.4989001172167865e-05,
+      "ML_domain_size_ang": 1769.239233503715
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -40.13490867869626,
+        -95.18069611061098,
+        56.29832657471773
+      ],
+      "real_space_b": [
+        203.10719595345702,
+        -36.14021877303292,
+        83.69409657172635
+      ],
+      "real_space_c": [
+        -69.94518776138071,
+        174.4511685621917,
+        245.0719368972797
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.033978920775795216,
+      "ML_domain_size_ang": 5260.330058668003
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -113.93040279208918,
+        27.96460595143016,
+        -7.816631565883022
+      ],
+      "real_space_b": [
+        28.681078314882985,
+        57.3220266855621,
+        -212.96371746528692
+      ],
+      "real_space_c": [
+        -64.90323449049541,
+        -288.57644860328537,
+        -86.41510327679694
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.00019382219472205103,
+      "ML_domain_size_ang": 1923.7432917147796
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        92.60825387744549,
+        -72.34992036121054,
+        -3.058985441364081
+      ],
+      "real_space_b": [
+        131.24452652744603,
+        164.8363233522586,
+        74.67559747729257
+      ],
+      "real_space_c": [
+        -57.72649473469086,
+        -86.22724565604214,
+        291.79101811543467
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.058398226852471154,
+      "ML_domain_size_ang": 3002.457238280969
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -11.107538500282619,
+        -103.76974935126738,
+        -53.48850933538159
+      ],
+      "real_space_b": [
+        -213.5526820423322,
+        43.1889959236996,
+        -39.44149258083532
+      ],
+      "real_space_c": [
+        75.60603899925447,
+        129.7052068962124,
+        -267.3335633370067
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.21954643153842035,
+      "ML_domain_size_ang": 1418.0378994677785
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -31.12716373502646,
+        -33.96681187909107,
+        -108.3143391554828
+      ],
+      "real_space_b": [
+        -125.83303659728885,
+        -161.69196527789194,
+        86.86740992702433
+      ],
+      "real_space_c": [
+        -241.86332215376044,
+        193.04301124919107,
+        8.968928676271648
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.0002791669315007968,
+      "ML_domain_size_ang": 1279.0836127217897
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        113.9864384472976,
+        14.514470736628974,
+        -24.200073199039753
+      ],
+      "real_space_b": [
+        -19.001383204590365,
+        -139.44365099738863,
+        -173.1338064316312
+      ],
+      "real_space_c": [
+        -69.68608823650104,
+        239.03089142936014,
+        -184.8697767070642
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.0025887423211024994,
+      "ML_domain_size_ang": 2025.3289555209394
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -114.10859740829186,
+        -27.538860338872723,
+        -3.3777743753333245
+      ],
+      "real_space_b": [
+        38.12864528697398,
+        -174.2220957111385,
+        132.35689459446607
+      ],
+      "real_space_c": [
+        -50.17326321676877,
+        177.46981194471283,
+        248.05810999984254
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.11751904536708013,
+      "ML_domain_size_ang": 5419.941725551391
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -114.94269989397549,
+        2.7607220153058165,
+        -23.804288032622793
+      ],
+      "real_space_b": [
+        9.400575829371746,
+        221.35151299233962,
+        -19.720714633577007
+      ],
+      "real_space_c": [
+        61.797767951056,
+        -29.514601715436683,
+        -301.82309576317624
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 8.339291083036443e-07,
+      "ML_domain_size_ang": 1487.4488990584496
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        53.91792752849036,
+        -12.093467937533495,
+        -103.88947678730605
+      ],
+      "real_space_b": [
+        -197.07938315539235,
+        11.14960482199727,
+        -103.58074387836237
+      ],
+      "real_space_c": [
+        28.505955987982937,
+        308.1100299849098,
+        -21.071784818460817
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.0002529548181591991,
+      "ML_domain_size_ang": 2429.7011228333804
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        26.09662213441959,
+        -103.12318007618218,
+        -49.71410648465041
+      ],
+      "real_space_b": [
+        156.64514264522165,
+        -35.1709439733172,
+        155.18429739849242
+      ],
+      "real_space_c": [
+        -210.01601936025298,
+        -140.0445836421853,
+        180.25334762829127
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.000698351828087156,
+      "ML_domain_size_ang": 2370.329622151255
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -89.61173215850945,
+        53.60666495561433,
+        53.34569951075059
+      ],
+      "real_space_b": [
+        66.73362082680416,
+        194.81577861853376,
+        -83.66764065156377
+      ],
+      "real_space_c": [
+        -177.31109316020346,
+        -46.92847976552383,
+        -250.69452683140477
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 6.79433155088562e-05,
+      "ML_domain_size_ang": 3840.4085310356963
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -92.78110565635059,
+        14.610404563787064,
+        -70.6693085461995
+      ],
+      "real_space_b": [
+        131.91815708156787,
+        -23.297180595505324,
+        -178.0107087880724
+      ],
+      "real_space_c": [
+        -50.26322333646768,
+        -305.78494749311375,
+        2.7711554937708667
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.013316267079829953,
+      "ML_domain_size_ang": 5787.049846379375
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        32.32625739813909,
+        -95.71473552554706,
+        59.992790656679766
+      ],
+      "real_space_b": [
+        53.54364853355908,
+        127.48784220854921,
+        174.54762848270192
+      ],
+      "real_space_c": [
+        -288.397435551532,
+        -28.77728659382458,
+        109.48647807901091
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 8.142813328853046e-05,
+      "ML_domain_size_ang": 1444.8362283295455
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        71.89199973312572,
+        -29.43223206514362,
+        -88.10399776971103
+      ],
+      "real_space_b": [
+        171.25920520393944,
+        -6.823848428607445,
+        142.02542611121876
+      ],
+      "real_space_c": [
+        -56.564138462750385,
+        -299.29358954589503,
+        53.826948559721984
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 5.206859291959338e-06,
+      "ML_domain_size_ang": 2345.7383580417377
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        98.03024361612187,
+        -64.10723035026938,
+        -2.60239954636619
+      ],
+      "real_space_b": [
+        17.302466123446806,
+        17.279182975925824,
+        226.1160884233633
+      ],
+      "real_space_c": [
+        -162.8434098093582,
+        -250.29599695042435,
+        31.587769631535565
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 9.68092398057264e-06,
+      "ML_domain_size_ang": 1162.731479423286
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -115.94232918733262,
+        4.2364126909173985,
+        18.902017944826873
+      ],
+      "real_space_b": [
+        33.43701818857524,
+        -45.761793129228,
+        215.3543406273438
+      ],
+      "real_space_c": [
+        21.04611440534009,
+        303.1505090057612,
+        61.15034195089513
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 7.97487165992675e-05,
+      "ML_domain_size_ang": 1757.3558097353207
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -66.0327962758205,
+        31.601628668016982,
+        91.28562232884235
+      ],
+      "real_space_b": [
+        178.69996568462545,
+        81.17285159210789,
+        101.16449753000497
+      ],
+      "real_space_c": [
+        -48.69882201206515,
+        265.7822597859137,
+        -127.23659407453262
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.00016300523843247903,
+      "ML_domain_size_ang": 1116.6693663721442
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        38.69165527714118,
+        10.581060164234247,
+        125.14677688988712
+      ],
+      "real_space_b": [
+        -207.19547271335264,
+        47.83277081360155,
+        60.014445166390175
+      ],
+      "real_space_c": [
+        -56.33544650207933,
+        -297.43107497461415,
+        42.564801965682754
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.0026490374930286543,
+      "ML_domain_size_ang": 736.1856323037655
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        29.32094364241654,
+        -57.78647424857928,
+        -98.12024276261424
+      ],
+      "real_space_b": [
+        -155.11510072852022,
+        113.49097502546307,
+        -113.19136724084349
+      ],
+      "real_space_c": [
+        209.13556898015742,
+        219.33540313328893,
+        -66.67907874117566
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.02259479685360012,
+      "ML_domain_size_ang": 11592.052170058168
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        60.44197692157093,
+        -93.44430398021791,
+        37.413807378569196
+      ],
+      "real_space_b": [
+        24.02960312102147,
+        95.09918999021991,
+        198.69886069658864
+      ],
+      "real_space_c": [
+        -261.4282493730279,
+        -131.28203075599984,
+        94.44861332587503
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 5.738630898166483e-06,
+      "ML_domain_size_ang": 1976.1665583043136
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -24.420004980873802,
+        40.56567127702213,
+        -106.35298808087254
+      ],
+      "real_space_b": [
+        65.20384358941104,
+        -194.3293908045756,
+        -89.09369208190645
+      ],
+      "real_space_c": [
+        -289.2500456954888,
+        -108.52440586057946,
+        25.021602410492317
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.37555267081937616,
+      "ML_domain_size_ang": 2936.991565773332
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -9.877836580118265,
+        -87.95111529373797,
+        -76.98500194301245
+      ],
+      "real_space_b": [
+        -188.80241152976689,
+        87.67481594530975,
+        -75.93866767539308
+      ],
+      "real_space_c": [
+        158.9660095536786,
+        163.18395555725434,
+        -206.82536535175387
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.06413037797780902,
+      "ML_domain_size_ang": 2811.492394402957
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        100.75301762769739,
+        59.75611649715432,
+        7.916951495305341
+      ],
+      "real_space_b": [
+        -41.455779473259575,
+        41.318573627368465,
+        215.70896094016229
+      ],
+      "real_space_c": [
+        148.18456519888423,
+        -260.2266416898239,
+        78.32451761415867
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.026816076789567777,
+      "ML_domain_size_ang": 6839.445304901546
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        34.281398449341,
+        14.64225465328792,
+        -111.24790564590364
+      ],
+      "real_space_b": [
+        -34.08502542163488,
+        -213.3720768104917,
+        -38.587069098259235
+      ],
+      "real_space_c": [
+        -279.6753870177146,
+        58.86123822494397,
+        -78.435653137635
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.37852945570768026,
+      "ML_domain_size_ang": 2269.376095786648
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -87.04993236377719,
+        -28.369459140290548,
+        73.68422921967398
+      ],
+      "real_space_b": [
+        26.292608660016395,
+        189.70180946540114,
+        104.09971874879176
+      ],
+      "real_space_c": [
+        -193.17407653293128,
+        125.49343054939786,
+        -179.89751248889308
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.15043013481222728,
+      "ML_domain_size_ang": 1672.3733741385377
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        5.424705891520885,
+        -55.22533269945887,
+        103.57763477324065
+      ],
+      "real_space_b": [
+        -221.68000069747922,
+        13.836854004421808,
+        18.987628709900747
+      ],
+      "real_space_c": [
+        -29.371334367473352,
+        -272.95785125811307,
+        -143.99689016578031
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.00032355863449032464,
+      "ML_domain_size_ang": 1459.371160463188
+    },
+    {
+      "__id__": "crystal",
+      "real_space_a": [
+        -32.81952357657543,
+        -69.5030435346608,
+        88.79158252051319
+      ],
+      "real_space_b": [
+        207.01655601217269,
+        -76.39375921903121,
+        16.719895353405146
+      ],
+      "real_space_c": [
+        66.57469091160854,
+        224.2046884529157,
+        200.1074578898284
+      ],
+      "space_group_hall_symbol": " P 2ac 2ab",
+      "ML_half_mosaicity_deg": 0.21831723567687442,
+      "ML_domain_size_ang": 5216.5907845649535
+    }
+  ],
+  "profile": [],
+  "scaling_model": []
+}


### PR DESCRIPTION
Add a mechanism to select simulated crystal structure via `crystal.structure = *ferredoxin PSII` parameter and include all necessary psii files to this aim to this repository. Missing Mn3+/4+ spectra to be added soon. 