### PR TITLE
Mp big objects

### DIFF
--- a/kpp_utils/LY99_batch.py
+++ b/kpp_utils/LY99_batch.py
@@ -7,7 +7,7 @@ start_elapse = time()
 
 from scitbx.matrix import sqr
 import libtbx.load_env # possibly implicit
-from omptbx import omp_get_num_procs
+from omptbx import omp_get_num_procs, omp_set_num_threads
 
 # %%% boilerplate specialize to packaged big data %%%
 
@@ -31,6 +31,7 @@ from exafel_project.kpp_utils.ferredoxin import basic_detector_rayonix
 from exafel_project.kpp_utils.amplitudes_spread_ferredoxin import amplitudes_spread_ferredoxin
 from exafel_project.kpp_utils.amplitudes_spread_psii import amplitudes_spread_psii
 from exafel_project.kpp_utils.mp_utils import bcast_large_dict
+
 
 def tst_one(image,spectra,crystal,random_orientation,sfall_channels,gpu_channels_singleton,rank,params,**kwargs):
   iterator = spectra.generate_recast_renormalized_image(image=image%100000,energy=params.beam.mean_wavelength,

--- a/kpp_utils/LY99_batch.py
+++ b/kpp_utils/LY99_batch.py
@@ -85,16 +85,15 @@ def run_LY99_batch(test_without_mpi=False):
     from LS49.spectra.generate_spectra import spectra_simulation
     from LS49.sim.step4_pad import microcrystal
     print("hello2 from rank %d of %d"%(rank,size))
-    SS = spectra_simulation()
-    C = microcrystal(Deff_A = 4000, length_um = 4., beam_diameter_um = 1.0) # assume smaller than 10 um crystals
-    random_orientations = legacy_random_orientations(N_total)
-    transmitted_info = dict(spectra = SS,
-                            crystal = C,
-                            sfall_info = sfall_channels,
-                            random_orientations = random_orientations)
+    transmitted_info = {
+      'spectra': spectra_simulation(),  # assume smaller than 10 um crystals
+      'crystal': microcrystal(Deff_A=4000, length_um=4., beam_diameter_um=1.0),
+      'random_orientations': legacy_random_orientations(N_total)}
   else:
     transmitted_info = None
-  transmitted_info = bcast_dict_1by1(comm, transmitted_info, root=0)
+  transmitted_info = comm.bcast(transmitted_info, root=0)
+  sfall_channels = bcast_dict_1by1(comm, sfall_channels, root=0)
+  transmitted_info['sfall_info'] = bcast_dict_1by1(comm, sfall_channels, root=0)
   comm.barrier()
   parcels = list(range(rank,N_total,N_stride))
 

--- a/kpp_utils/LY99_batch.py
+++ b/kpp_utils/LY99_batch.py
@@ -30,7 +30,7 @@ from exafel_project.kpp_utils.phil import parse_input
 from exafel_project.kpp_utils.ferredoxin import basic_detector_rayonix
 from exafel_project.kpp_utils.amplitudes_spread_ferredoxin import amplitudes_spread_ferredoxin
 from exafel_project.kpp_utils.amplitudes_spread_psii import amplitudes_spread_psii
-from exafel_project.kpp_utils.mp_utils import bcast_dict_1by1
+from exafel_project.kpp_utils.mp_utils import bcast_large_dict
 
 def tst_one(image,spectra,crystal,random_orientation,sfall_channels,gpu_channels_singleton,rank,params,**kwargs):
   iterator = spectra.generate_recast_renormalized_image(image=image%100000,energy=params.beam.mean_wavelength,
@@ -92,8 +92,8 @@ def run_LY99_batch(test_without_mpi=False):
   else:
     transmitted_info = None
   transmitted_info = comm.bcast(transmitted_info, root=0)
-  sfall_channels = bcast_dict_1by1(comm, sfall_channels, root=0)
-  transmitted_info['sfall_info'] = bcast_dict_1by1(comm, sfall_channels, root=0)
+  sfall_channels = bcast_large_dict(comm, sfall_channels, root=0)
+  transmitted_info['sfall_info'] = sfall_channels
   comm.barrier()
   parcels = list(range(rank,N_total,N_stride))
 

--- a/kpp_utils/LY99_batch.py
+++ b/kpp_utils/LY99_batch.py
@@ -86,10 +86,12 @@ def run_LY99_batch(test_without_mpi=False):
     from LS49.spectra.generate_spectra import spectra_simulation
     from LS49.sim.step4_pad import microcrystal
     print("hello2 from rank %d of %d"%(rank,size))
-    transmitted_info = {
-      'spectra': spectra_simulation(),  # assume smaller than 10 um crystals
-      'crystal': microcrystal(Deff_A=4000, length_um=4., beam_diameter_um=1.0),
-      'random_orientations': legacy_random_orientations(N_total)}
+    SS = spectra_simulation()
+    C = microcrystal(Deff_A=4000, length_um=4., beam_diameter_um=1.0)  # assume smaller than 10 um crystals
+    random_orientations = legacy_random_orientations(N_total)
+    transmitted_info = dict(spectra=SS,
+                            crystal=C,
+                            random_orientations=random_orientations)
   else:
     transmitted_info = None
   transmitted_info = comm.bcast(transmitted_info, root=0)

--- a/kpp_utils/LY99_batch.py
+++ b/kpp_utils/LY99_batch.py
@@ -7,7 +7,7 @@ start_elapse = time()
 
 from scitbx.matrix import sqr
 import libtbx.load_env # possibly implicit
-from omptbx import omp_get_num_procs, omp_set_num_threads
+from omptbx import omp_get_num_procs
 
 # %%% boilerplate specialize to packaged big data %%%
 

--- a/kpp_utils/LY99_batch.py
+++ b/kpp_utils/LY99_batch.py
@@ -30,6 +30,7 @@ from exafel_project.kpp_utils.phil import parse_input
 from exafel_project.kpp_utils.ferredoxin import basic_detector_rayonix
 from exafel_project.kpp_utils.amplitudes_spread_ferredoxin import amplitudes_spread_ferredoxin
 from exafel_project.kpp_utils.amplitudes_spread_psii import amplitudes_spread_psii
+from exafel_project.kpp_utils.mp_utils import bcast_dict_1by1
 
 def tst_one(image,spectra,crystal,random_orientation,sfall_channels,gpu_channels_singleton,rank,params,**kwargs):
   iterator = spectra.generate_recast_renormalized_image(image=image%100000,energy=params.beam.mean_wavelength,
@@ -93,7 +94,7 @@ def run_LY99_batch(test_without_mpi=False):
                             random_orientations = random_orientations)
   else:
     transmitted_info = None
-  transmitted_info = comm.bcast(transmitted_info, root = 0)
+  transmitted_info = bcast_dict_1by1(comm, transmitted_info, root=0)
   comm.barrier()
   parcels = list(range(rank,N_total,N_stride))
 

--- a/kpp_utils/LY99_batch.py
+++ b/kpp_utils/LY99_batch.py
@@ -87,14 +87,14 @@ def run_LY99_batch(test_without_mpi=False):
     from LS49.sim.step4_pad import microcrystal
     print("hello2 from rank %d of %d"%(rank,size))
     SS = spectra_simulation()
-    C = microcrystal(Deff_A=4000, length_um=4., beam_diameter_um=1.0)  # assume smaller than 10 um crystals
+    C = microcrystal(Deff_A = 4000, length_um = 4., beam_diameter_um = 1.0) # assume smaller than 10 um crystals
     random_orientations = legacy_random_orientations(N_total)
-    transmitted_info = dict(spectra=SS,
-                            crystal=C,
-                            random_orientations=random_orientations)
+    transmitted_info = dict(spectra = SS,
+                            crystal = C,
+                            random_orientations = random_orientations)
   else:
     transmitted_info = None
-  transmitted_info = comm.bcast(transmitted_info, root=0)
+  transmitted_info = comm.bcast(transmitted_info, root = 0)
   sfall_channels = bcast_large_dict(comm, sfall_channels, root=0)
   transmitted_info['sfall_info'] = sfall_channels
   comm.barrier()

--- a/kpp_utils/amplitudes_spread_psii.py
+++ b/kpp_utils/amplitudes_spread_psii.py
@@ -8,6 +8,8 @@ from scitbx.array_family import flex
 
 from scipy import constants
 
+from exafel_project.kpp_utils.mp_utils import gather_dict_1by1
+
 ENERGY_CONV = 1e10 * constants.c * constants.h / constants.electron_volt
 
 
@@ -68,10 +70,7 @@ def amplitudes_spread_psii(comm):
                                     newvalue=wavelengths[x])
     sfall_channels[x] = GF.get_amplitudes()
 
-  reports = comm.gather(sfall_channels, root=0)
-  if rank == 0:
-    sfall_channels = {}
-    for report in reports: sfall_channels.update(report)
+  sfall_channels = gather_dict_1by1(comm, sfall_channels, root=0)
   comm.barrier()
   return sfall_channels
 

--- a/kpp_utils/amplitudes_spread_psii.py
+++ b/kpp_utils/amplitudes_spread_psii.py
@@ -8,7 +8,7 @@ from scitbx.array_family import flex
 
 from scipy import constants
 
-from exafel_project.kpp_utils.mp_utils import gather_dict_1by1
+from exafel_project.kpp_utils.mp_utils import gather_dict_1by1_alt
 
 ENERGY_CONV = 1e10 * constants.c * constants.h / constants.electron_volt
 
@@ -70,7 +70,7 @@ def amplitudes_spread_psii(comm):
                                     newvalue=wavelengths[x])
     sfall_channels[x] = GF.get_amplitudes()
 
-  sfall_channels = gather_dict_1by1(comm, sfall_channels, root=0)
+  sfall_channels = gather_dict_1by1_alt(comm, sfall_channels, root=0)
   comm.barrier()
   return sfall_channels
 

--- a/kpp_utils/amplitudes_spread_psii.py
+++ b/kpp_utils/amplitudes_spread_psii.py
@@ -8,7 +8,7 @@ from scitbx.array_family import flex
 
 from scipy import constants
 
-from exafel_project.kpp_utils.mp_utils import collect_dict_1by1
+from exafel_project.kpp_utils.mp_utils import collect_large_dict
 
 ENERGY_CONV = 1e10 * constants.c * constants.h / constants.electron_volt
 
@@ -70,7 +70,7 @@ def amplitudes_spread_psii(comm):
                                     newvalue=wavelengths[x])
     sfall_channels[x] = GF.get_amplitudes()
 
-  sfall_channels = collect_dict_1by1(comm, sfall_channels, root=0)
+  sfall_channels = collect_large_dict(comm, sfall_channels, root=0)
   comm.barrier()
   return sfall_channels
 

--- a/kpp_utils/amplitudes_spread_psii.py
+++ b/kpp_utils/amplitudes_spread_psii.py
@@ -8,7 +8,7 @@ from scitbx.array_family import flex
 
 from scipy import constants
 
-from exafel_project.kpp_utils.mp_utils import gather_dict_1by1_alt
+from exafel_project.kpp_utils.mp_utils import collect_dict_1by1
 
 ENERGY_CONV = 1e10 * constants.c * constants.h / constants.electron_volt
 
@@ -70,7 +70,7 @@ def amplitudes_spread_psii(comm):
                                     newvalue=wavelengths[x])
     sfall_channels[x] = GF.get_amplitudes()
 
-  sfall_channels = gather_dict_1by1_alt(comm, sfall_channels, root=0)
+  sfall_channels = collect_dict_1by1(comm, sfall_channels, root=0)
   comm.barrier()
   return sfall_channels
 

--- a/kpp_utils/amplitudes_spread_psii.py
+++ b/kpp_utils/amplitudes_spread_psii.py
@@ -8,7 +8,7 @@ from scitbx.array_family import flex
 
 from scipy import constants
 
-from exafel_project.kpp_utils.mp_utils import collect_dict_1by1_alt
+from exafel_project.kpp_utils.mp_utils import collect_dict_1by1
 
 ENERGY_CONV = 1e10 * constants.c * constants.h / constants.electron_volt
 
@@ -70,7 +70,7 @@ def amplitudes_spread_psii(comm):
                                     newvalue=wavelengths[x])
     sfall_channels[x] = GF.get_amplitudes()
 
-  sfall_channels = collect_dict_1by1_alt(comm, sfall_channels, root=0)
+  sfall_channels = collect_dict_1by1(comm, sfall_channels, root=0)
   comm.barrier()
   return sfall_channels
 

--- a/kpp_utils/amplitudes_spread_psii.py
+++ b/kpp_utils/amplitudes_spread_psii.py
@@ -8,7 +8,7 @@ from scitbx.array_family import flex
 
 from scipy import constants
 
-from exafel_project.kpp_utils.mp_utils import collect_dict_1by1
+from exafel_project.kpp_utils.mp_utils import collect_dict_1by1_alt
 
 ENERGY_CONV = 1e10 * constants.c * constants.h / constants.electron_volt
 
@@ -70,7 +70,7 @@ def amplitudes_spread_psii(comm):
                                     newvalue=wavelengths[x])
     sfall_channels[x] = GF.get_amplitudes()
 
-  sfall_channels = collect_dict_1by1(comm, sfall_channels, root=0)
+  sfall_channels = collect_dict_1by1_alt(comm, sfall_channels, root=0)
   comm.barrier()
   return sfall_channels
 

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -28,3 +28,18 @@ def gather_dict_1by1(comm, data, root=0):
     received[key] = comm.sendrecv(data[key], dest=root, source=source)
   print(f'gather3: {rank=}, {datetime.now()=}')
   return received
+
+
+def gather_dict_1by1_alt(comm, data, root=0):
+  """Gather dictionary elements by sending them one-by-one to avoid overflow"""
+  rank = comm.rank
+  print(f'gather1: {rank=}, {len(data)=}, {datetime.now()=}')
+  received = []
+  max_data_lengths = max(comm.all2all(len(data), root=root))
+  data_list = list(data.items()) + [None] * max_data_lengths
+  for index in range(max_data_lengths):
+    print(f'gather2: {index=}, {datetime.now()=}')
+    gathered = comm.gather(data_list[index], root=root)
+    received.extend(g for g in gathered if g is not None)
+  print(f'gather3: {rank=}, {len(received)=}, {datetime.now()=}')
+  return received

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -36,7 +36,7 @@ def gather_dict_1by1_alt(comm, data, root=0):
   rank = comm.rank
   print(f'gather1: {rank=}, {len(data)=}, {datetime.now()=}')
   received = []
-  max_data_length = comm.reduce(max(data), op=MPI.MAX, root=root)
+  max_data_length = comm.reduce(len(data), op=MPI.MAX, root=root)
   data_list = list(data.items()) + [None] * max_data_length
   for index in range(max_data_length):
     print(f'gather2: {index=}, {datetime.now()=}')

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -1,0 +1,20 @@
+def bcast_dict_1by1(comm, data, root=0):
+  """Broadcast dictionary elements one-by-one to avoid MPI overflow issues"""
+  received = {}
+  for key, value in data.items():
+    received[key] = comm.bcast(value, root=root)
+  return received
+
+
+def gather_dict_1by1(comm, data, root=0):
+  """Gather dictionary elements by sending them one-by-one to avoid overflow"""
+  rank = comm.rank
+  received = {}
+  key_rank_map = {key: rank for key in data.keys()}
+  key_rank_map = comm.bcast(key_rank_map, root=root)
+  for key, source in key_rank_map.items():
+    if rank == source:
+        comm.Send(data[key], dest=root)
+    if rank == root:
+        received[key] = comm.recv(source=source)
+  return received

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -1,17 +1,21 @@
+from datetime import datetime
+
+
 def bcast_dict_1by1(comm, data, root=0):
   """Broadcast dictionary elements one-by-one to avoid MPI overflow issues"""
-  print(f'bcast1: {comm.rank=}, {data.items()}')
+  print(f'bcast1: {comm.rank=}, {datetime.now()=}')
   received = {}
   for key, value in data.items():
+    print(f'bcast2: {key=}, {datetime.now()=}')
     received[key] = comm.bcast([value], root=root)[0]
-  print(f'bcast2: {comm.rank=}, {received.items()}')
+  print(f'bcast3: {comm.rank=}, {datetime.now()=}')
   return received
 
 
 def gather_dict_1by1(comm, data, root=0):
   """Gather dictionary elements by sending them one-by-one to avoid overflow"""
   rank = comm.rank
-  print(f'gather1: {rank=}, {data.items()}')
+  print(f'gather1: {rank=}, {datetime.now()=}')
   received = {}
   key_rank_map = {key: rank for key in data.keys()}
   if rank == 0:
@@ -20,6 +24,7 @@ def gather_dict_1by1(comm, data, root=0):
       key_rank_map.update(key_rank_from_single_rank)
   key_rank_map = comm.bcast(key_rank_map, root=root)
   for key, source in key_rank_map.items():
+    print(f'gather2: {key=}, {datetime.now()=}')
     received[key] = comm.sendrecv(data[key], dest=root, source=source)
-  print(f'gather2: {rank=}, {received.items()}')
+  print(f'gather3: {rank=}, {datetime.now()=}')
   return received

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -1,5 +1,16 @@
-from sys import getsizeof
 from libtbx.mpi4py import MPI
+
+
+"""
+mpi4py has an internal limit for the length of passed element. The overall size
+of sent/received/gathered/broadcasted objects must be smaller than 2**31 bytes.
+Attempting to pass a larger object causes an `OverflowError` or `SystemError`.
+The dictionaries of structure factors created by the EXAFEL scripts can easily
+exceed this internal limit, which can raise errors with ambiguous traceback.
+The `*_large_*` functions defined below circumvent this issue by passing values
+either one-by-one or in slices, which can negatively affect the execution time
+of the preparatory stage, but otherwise circumvents the mpi-related issues.
+"""
 
 
 def bcast_large_dict(comm, data, root=0):

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -21,7 +21,7 @@ def collect_dict_1by1_alt(comm, data, root=0):
   max_data_length = comm.bcast(max_data_length, root=root)
   data_list = list(data.items()) + [None] * max_data_length
   for data_row in range(max_data_length):
-    for source in comm.size:
+    for source in range(comm.size):
       print(f'sending from {source=} to {root=}')
       recv = comm.sendrecv(data_list[data_row], dest=root, source=source)
       if on_root and recv is not None:

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -17,25 +17,7 @@ def bcast_dict_1by1(comm, data, root=0):
   return received
 
 
-def gather_dict_1by1(comm, data, root=0):
-  """Gather dictionary elements by sending them one-by-one to avoid overflow"""
-  rank = comm.rank
-  print(f'gather1: {rank=}, {datetime.now()=}')
-  received = {}
-  key_rank_map = {key: rank for key in data.keys()}
-  if rank == 0:
-    key_rank_list = comm.gather(key_rank_map, root=root)
-    for key_rank_from_single_rank in key_rank_list:
-      key_rank_map.update(key_rank_from_single_rank)
-  key_rank_map = comm.bcast(key_rank_map, root=root)
-  for key, source in key_rank_map.items():
-    print(f'gather2: {key=}, {datetime.now()=}')
-    received[key] = comm.sendrecv(data[key], dest=root, source=source)
-  print(f'gather3: {rank=}, {datetime.now()=}')
-  return received
-
-
-def gather_dict_1by1_alt(comm, data, root=0):
+def collect_dict_1by1(comm, data, root=0):
   """Gather dictionary elements by sending them one-by-one to avoid overflow"""
   rank = comm.rank
   print(f'gather1: {rank=}, {len(data)=}, {datetime.now()=}')

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -1,35 +1,27 @@
-from datetime import datetime
 from libtbx.mpi4py import MPI
 
 
 def bcast_dict_1by1(comm, data, root=0):
   """Broadcast dictionary elements one-by-one to avoid MPI overflow issues"""
-  rank = comm.rank
-  print(f'bcast1: {comm.rank=}, {datetime.now()=}')
+  on_root = root == comm.rank
   received = {}
   keys = list(data.keys()) if data is not None else None
   keys = comm.bcast(keys, root=root)
   for key in keys:
-    print(f'bcast2: {key=}, {datetime.now()=}')
-    value = data[key] if rank == root else None
+    value = data[key] if on_root else None
     received[key] = comm.bcast(value, root=root)
-  print(f'bcast3: {comm.rank=}, {datetime.now()=}')
   return received
 
 
 def collect_dict_1by1(comm, data, root=0):
   """Gather dictionary elements by sending them one-by-one to avoid overflow"""
-  rank = comm.rank
-  print(f'gather1: {rank=}, {len(data)=}, {datetime.now()=}')
+  on_root = root == comm.rank
   received = []
   max_data_length = comm.reduce(len(data), op=MPI.MAX, root=root)
   max_data_length = comm.bcast(max_data_length, root=root)
   data_list = list(data.items()) + [None] * max_data_length
   for data_row in range(max_data_length):
-    print(f'gather2: {data_row=}, {datetime.now()=}')
     gathered = comm.gather(data_list[data_row], root=root)
-    if rank == root:
+    if on_root:
       received.extend(g for g in gathered if g is not None)
-  print(f'gather3: {rank=}, {len(received)=}, {datetime.now()=}')
-  return {r[0]: r[1] for r in received if r is not None} \
-    if rank == root else None
+  return {r[0]: r[1] for r in received if r is not None} if on_root else None

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -2,7 +2,7 @@ def bcast_dict_1by1(comm, data, root=0):
   """Broadcast dictionary elements one-by-one to avoid MPI overflow issues"""
   received = {}
   for key, value in data.items():
-    received[key] = comm.bcast(value, root=root)
+    received[key] = comm.bcast([value], root=root)[0]
   return received
 
 
@@ -14,7 +14,7 @@ def gather_dict_1by1(comm, data, root=0):
   key_rank_map = comm.bcast(key_rank_map, root=root)
   for key, source in key_rank_map.items():
     if rank == source:
-        comm.Send(data[key], dest=root)
+        comm.send([data[key]], dest=root)
     if rank == root:
-        received[key] = comm.recv(source=source)
+        received[key] = comm.recv(source=source)[0]
   return received

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -16,18 +16,20 @@ def bcast_dict_1by1(comm, data, root=0):
 def collect_dict_1by1(comm, data, root=0):
   """Gather dictionary elements by sending them one-by-one to avoid overflow"""
   on_root = root == comm.rank
-  received = []
   max_data_length = comm.reduce(len(data), op=MPI.MAX, root=root)
   max_data_length = comm.bcast(max_data_length, root=root)
   data_list = list(data.items()) + [None] * max_data_length
-  for data_row in range(max_data_length):
-    for source in range(comm.size):
+  received = [None] * max_data_length * (comm.size - 1)
+  for i, row in enumerate(range(max_data_length)):
+    for j, source in enumerate(range(1, comm.size)):
+      ij = i * (comm.size - 1) + j
       comm.barrier()
       print(f'sending from {source=} to {root=}')
-      recv = comm.sendrecv(data_list[data_row], dest=root, source=source)
-      if on_root and recv is not None:
-        received.append(recv)
-  return {r[0]: r[1] for r in received if r is not None} if on_root else None
+      received[ij] = comm.sendrecv(data_list[row], dest=root, source=source)
+      print(f'received from {source=} to {root=}')
+  if on_root:
+    data.update({r[0]: r[1] for r in received if r is not None})
+  return data if on_root else None
 
 
 def collect_dict_stripes(comm, data, root=0):

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -30,8 +30,7 @@ def collect_large_dict(comm: MPI.Comm, data: dict, root: int = 0) -> dict:
   then recreate the dictionary from "gathered" list elements."""
   rank = comm.rank
   on_root = root == rank
-  max_data_length = comm.reduce(len(data), op=MPI.MAX, root=root)
-  max_data_length = comm.bcast(max_data_length, root=root)
+  max_data_length = comm.allreduce(len(data), op=MPI.MAX)
   data_list = list(data.items()) + [None] * max_data_length
   received = []
   for i, row in enumerate(range(max_data_length)):

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -42,6 +42,7 @@ def gather_dict_1by1_alt(comm, data, root=0):
   for index in range(max_data_length):
     print(f'gather2: {index=}, {datetime.now()=}')
     gathered = comm.gather(data_list[index], root=root)
-    received.extend(g for g in gathered if g is not None)
+    if rank == root:
+      received.extend(g for g in gathered if g is not None)
   print(f'gather3: {rank=}, {len(received)=}, {datetime.now()=}')
   return received

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -2,18 +2,7 @@ from sys import getsizeof
 from libtbx.mpi4py import MPI
 
 
-def bcast_dict(comm, data, root=0):
-  """Broadcast dict directly or using one of helper functions if too large"""
-  max_data_size = comm.reduce(getsizeof(data), MPI.MAX, root=root)
-  max_data_size = comm.bcast(max_data_size, root=root)
-  if max_data_size * comm.size < 2 ** 31:
-    received = comm.bcast(data, root=root)
-  else:
-    received = _bcast_dict_1by1(comm=comm, data=data, root=root)
-  return received
-
-
-def _bcast_dict(comm, data, root=0):
+def bcast_large_dict(comm, data, root=0):
   """Broadcast dictionary elements one-by-one to avoid MPI overflow issues"""
   on_root = root == comm.rank
   received = {}
@@ -25,27 +14,7 @@ def _bcast_dict(comm, data, root=0):
   return received
 
 
-def collect_dict(comm, data, root=0):
-  """Broadcast dict directly or using one of helper functions if too large"""
-  max_data_size = comm.reduce(getsizeof(data), MPI.MAX, root=root)
-  max_data_size = comm.bcast(max_data_size, root=root)
-  max_value_size = max([getsizeof(i) for i in data.values()])
-  max_value_size = comm.reduce(max_value_size, MPI.MAX, root=root)
-  max_value_size = comm.bcast(max_value_size, root=root)
-  if max_data_size * comm.size < 2 ** 31:
-    received = {} if comm.rank == root else None
-    received_list = comm.gather(data, root=root)
-    if comm.rank == root:
-      for received_item in received_list:
-        received.update(received_item)
-  elif max_value_size * comm.size < 2 ** 31:
-    received = _bcast_dict_1by1(comm=comm, data=data, root=root)
-  else:
-    received = _bcast_dict_1by1(comm=comm, data=data, root=root)
-  return data
-
-
-def collect_dict_1by1(comm, data, root=0):
+def collect_large_dict(comm, data, root=0):
   """Gather dictionary elements by sending them one-by-one to avoid overflow"""
   rank = comm.rank
   on_root = root == rank
@@ -58,25 +27,9 @@ def collect_dict_1by1(comm, data, root=0):
       tag = i * (comm.size - 1) + j
       comm.barrier()
       if rank == source:
-        print(f'sending from {source=} to {root=}')
         comm.send(data_list[row], dest=root, tag=tag)
       elif on_root:
-        print(f'received from {source=} to {root=}')
         received.append(comm.recv(source=source, tag=tag))
   if on_root:
     data.update({r[0]: r[1] for r in received if r is not None})
   return data if on_root else None
-
-
-def collect_dict_stripes(comm, data, root=0):
-  """Gather dictionary elements by sending them one-by-one to avoid overflow"""
-  on_root = root == comm.rank
-  received = []
-  max_data_length = comm.reduce(len(data), op=MPI.MAX, root=root)
-  max_data_length = comm.bcast(max_data_length, root=root)
-  data_list = list(data.items()) + [None] * max_data_length
-  for data_row in range(max_data_length):
-    gathered = comm.gather(data_list[data_row], root=root)
-    if on_root:
-      received.extend(g for g in gathered if g is not None)
-  return {r[0]: r[1] for r in received if r is not None} if on_root else None

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -35,7 +35,7 @@ def gather_dict_1by1_alt(comm, data, root=0):
   rank = comm.rank
   print(f'gather1: {rank=}, {len(data)=}, {datetime.now()=}')
   received = []
-  max_data_lengths = max(comm.all2all(len(data), root=root))
+  max_data_lengths = max(comm.alltoall(len(data), root=root))
   data_list = list(data.items()) + [None] * max_data_lengths
   for index in range(max_data_lengths):
     print(f'gather2: {index=}, {datetime.now()=}')

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -13,7 +13,7 @@ of the preparatory stage, but otherwise circumvents the mpi-related issues.
 """
 
 
-def bcast_large_dict(comm, data, root=0):
+def bcast_large_dict(comm: MPI.Comm, data: dict, root: int = 0) -> dict:
   """Broadcast dictionary elements one-by-one to avoid MPI overflow issues"""
   on_root = root == comm.rank
   received = {}
@@ -25,8 +25,9 @@ def bcast_large_dict(comm, data, root=0):
   return received
 
 
-def collect_large_dict(comm, data, root=0):
-  """Gather dictionary elements by sending them one-by-one to avoid overflow"""
+def collect_large_dict(comm: MPI.Comm, data: dict, root: int = 0) -> dict:
+  """Gather dictionary elements one-by-one to avoid MPI overflow issues,
+  then recreate the dictionary from "gathered" list elements."""
   rank = comm.rank
   on_root = root == rank
   max_data_length = comm.reduce(len(data), op=MPI.MAX, root=root)

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from libtbx.mpi4py import MPI
 
 

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -4,7 +4,8 @@ from libtbx.mpi4py import MPI
 
 def bcast_dict(comm, data, root=0):
   """Broadcast dict directly or using one of helper functions if too large"""
-  max_data_size = comm.reduce(getsizeof(data), MPI.MAX, root=0)
+  max_data_size = comm.reduce(getsizeof(data), MPI.MAX, root=root)
+  max_data_size = comm.bcast(max_data_size, root=root)
   if max_data_size * comm.size < 2 ** 31:
     data = comm.bcast(data, root=root)
   else:

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -21,7 +21,7 @@ def collect_large_dict(comm, data, root=0):
   max_data_length = comm.reduce(len(data), op=MPI.MAX, root=root)
   max_data_length = comm.bcast(max_data_length, root=root)
   data_list = list(data.items()) + [None] * max_data_length
-  received = [None] * max_data_length * (comm.size - 1)
+  received = []
   for i, row in enumerate(range(max_data_length)):
     for j, source in enumerate(range(1, comm.size)):
       tag = i * (comm.size - 1) + j

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -49,4 +49,5 @@ def gather_dict_1by1_alt(comm, data, root=0):
     if rank == root:
       received.extend(g for g in gathered if g is not None)
   print(f'gather3: {rank=}, {len(received)=}, {datetime.now()=}')
-  return received if rank == root else None
+  return {r[0]: r[1] for r in received if r is not None} \
+    if rank == root else None

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -37,6 +37,7 @@ def gather_dict_1by1_alt(comm, data, root=0):
   print(f'gather1: {rank=}, {len(data)=}, {datetime.now()=}')
   received = []
   max_data_length = comm.reduce(len(data), op=MPI.MAX, root=root)
+  max_data_length = comm.bcast(max_data_length, root=root)
   data_list = list(data.items()) + [None] * max_data_length
   for index in range(max_data_length):
     print(f'gather2: {index=}, {datetime.now()=}')

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -13,7 +13,7 @@ def bcast_dict_1by1(comm, data, root=0):
   return received
 
 
-def collect_dict_1by1_alt(comm, data, root=0):
+def collect_dict_1by1(comm, data, root=0):
   """Gather dictionary elements by sending them one-by-one to avoid overflow"""
   on_root = root == comm.rank
   received = []
@@ -30,7 +30,7 @@ def collect_dict_1by1_alt(comm, data, root=0):
   return {r[0]: r[1] for r in received if r is not None} if on_root else None
 
 
-def collect_dict_1by1(comm, data, root=0):
+def collect_dict_stripes(comm, data, root=0):
   """Gather dictionary elements by sending them one-by-one to avoid overflow"""
   on_root = root == comm.rank
   received = []

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -1,13 +1,4 @@
-from datetime import datetime
-from typing import Callable
 from libtbx.mpi4py import MPI
-
-
-def rlog_factory(rank: int = 0) -> Callable[[str], None]:
-  """A convenience function to avoid repeating `print(rank, time(), msg)`."""
-  def rlog_function(msg: str):
-    print(f'Rank{rank:4d}, Time {datetime.now()}: {msg}')
-  return rlog_function
 
 
 """

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -13,6 +13,22 @@ def bcast_dict_1by1(comm, data, root=0):
   return received
 
 
+def collect_dict_1by1_alt(comm, data, root=0):
+  """Gather dictionary elements by sending them one-by-one to avoid overflow"""
+  on_root = root == comm.rank
+  received = []
+  max_data_length = comm.reduce(len(data), op=MPI.MAX, root=root)
+  max_data_length = comm.bcast(max_data_length, root=root)
+  data_list = list(data.items()) + [None] * max_data_length
+  for data_row in range(max_data_length):
+    for source in comm.size:
+      print(f'sending from {source=} to {root=}')
+      recv = comm.sendrecv(data_list[data_row], dest=root, source=source)
+      if on_root and recv is not None:
+        received.append(recv)
+  return {r[0]: r[1] for r in received if r is not None} if on_root else None
+
+
 def collect_dict_1by1(comm, data, root=0):
   """Gather dictionary elements by sending them one-by-one to avoid overflow"""
   on_root = root == comm.rank

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from libtbx.mpi4py import MPI
 
 
 def bcast_dict_1by1(comm, data, root=0):
@@ -35,9 +36,9 @@ def gather_dict_1by1_alt(comm, data, root=0):
   rank = comm.rank
   print(f'gather1: {rank=}, {len(data)=}, {datetime.now()=}')
   received = []
-  max_data_lengths = max(comm.alltoall(len(data)))
-  data_list = list(data.items()) + [None] * max_data_lengths
-  for index in range(max_data_lengths):
+  max_data_length = comm.reduce(max(data), op=MPI.MAX, root=root)
+  data_list = list(data.items()) + [None] * max_data_length
+  for index in range(max_data_length):
     print(f'gather2: {index=}, {datetime.now()=}')
     gathered = comm.gather(data_list[index], root=root)
     received.extend(g for g in gathered if g is not None)

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -1,21 +1,25 @@
 def bcast_dict_1by1(comm, data, root=0):
   """Broadcast dictionary elements one-by-one to avoid MPI overflow issues"""
-  print(f'bcast: {comm.rank=}, {data.items()}')
+  print(f'bcast1: {comm.rank=}, {data.items()}')
   received = {}
   for key, value in data.items():
     received[key] = comm.bcast([value], root=root)[0]
-  print(f'bcast: {comm.rank=}, {received.items()}')
+  print(f'bcast2: {comm.rank=}, {received.items()}')
   return received
 
 
 def gather_dict_1by1(comm, data, root=0):
   """Gather dictionary elements by sending them one-by-one to avoid overflow"""
   rank = comm.rank
-  print(f'bcast: {rank=}, {data.items()}')
+  print(f'gather1: {rank=}, {data.items()}')
   received = {}
   key_rank_map = {key: rank for key in data.keys()}
+  if rank == 0:
+    key_rank_list = comm.gather(key_rank_map, root=root)
+    for key_rank_from_single_rank in key_rank_list:
+      key_rank_map.update(key_rank_from_single_rank)
   key_rank_map = comm.bcast(key_rank_map, root=root)
   for key, source in key_rank_map.items():
     received[key] = comm.sendrecv(data[key], dest=root, source=source)
-  print(f'gather: {rank=}, {received.items()}')
+  print(f'gather2: {rank=}, {received.items()}')
   return received

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -22,6 +22,7 @@ def collect_dict_1by1_alt(comm, data, root=0):
   data_list = list(data.items()) + [None] * max_data_length
   for data_row in range(max_data_length):
     for source in range(comm.size):
+      comm.barrier()
       print(f'sending from {source=} to {root=}')
       recv = comm.sendrecv(data_list[data_row], dest=root, source=source)
       if on_root and recv is not None:

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -4,13 +4,15 @@ from libtbx.mpi4py import MPI
 
 def bcast_dict_1by1(comm, data, root=0):
   """Broadcast dictionary elements one-by-one to avoid MPI overflow issues"""
+  rank = comm.rank
   print(f'bcast1: {comm.rank=}, {datetime.now()=}')
   received = {}
   keys = list(data.keys()) if data is not None else None
   keys = comm.bcast(keys, root=root)
   for key in keys:
     print(f'bcast2: {key=}, {datetime.now()=}')
-    received[key] = comm.bcast(data[key], root=root)
+    value = data[key] if rank == root else None
+    received[key] = comm.bcast(value, root=root)
   print(f'bcast3: {comm.rank=}, {datetime.now()=}')
   return received
 

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -1,20 +1,21 @@
 def bcast_dict_1by1(comm, data, root=0):
   """Broadcast dictionary elements one-by-one to avoid MPI overflow issues"""
+  print(f'bcast: {comm.rank=}, {data.items()}')
   received = {}
   for key, value in data.items():
     received[key] = comm.bcast([value], root=root)[0]
+  print(f'bcast: {comm.rank=}, {received.items()}')
   return received
 
 
 def gather_dict_1by1(comm, data, root=0):
   """Gather dictionary elements by sending them one-by-one to avoid overflow"""
   rank = comm.rank
+  print(f'bcast: {rank=}, {data.items()}')
   received = {}
   key_rank_map = {key: rank for key in data.keys()}
   key_rank_map = comm.bcast(key_rank_map, root=root)
   for key, source in key_rank_map.items():
-    if rank == source:
-        comm.send([data[key]], dest=root)
-    if rank == root:
-        received[key] = comm.recv(source=source)[0]
+    received[key] = comm.sendrecv(data[key], dest=root, source=source)
+  print(f'gather: {rank=}, {received.items()}')
   return received

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -1,4 +1,13 @@
+from datetime import datetime
+from typing import Callable
 from libtbx.mpi4py import MPI
+
+
+def rlog_factory(rank: int = 0) -> Callable[[str], None]:
+  """A convenience function to avoid repeating `print(rank, time(), msg)`."""
+  def rlog_function(msg: str):
+    print(f'Rank{rank:4d}, Time {datetime.now()}: {msg}')
+  return rlog_function
 
 
 """

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -6,7 +6,8 @@ def bcast_dict_1by1(comm, data, root=0):
   """Broadcast dictionary elements one-by-one to avoid MPI overflow issues"""
   print(f'bcast1: {comm.rank=}, {datetime.now()=}')
   received = {}
-  keys = comm.bcast(list(data.keys()), root=root)
+  keys = list(data.keys()) if data is not None else None
+  keys = comm.bcast(keys, root=root)
   for key in keys:
     print(f'bcast2: {key=}, {datetime.now()=}')
     received[key] = comm.bcast(data[key], root=root)

--- a/kpp_utils/mp_utils.py
+++ b/kpp_utils/mp_utils.py
@@ -35,7 +35,7 @@ def gather_dict_1by1_alt(comm, data, root=0):
   rank = comm.rank
   print(f'gather1: {rank=}, {len(data)=}, {datetime.now()=}')
   received = []
-  max_data_lengths = max(comm.alltoall(len(data), root=root))
+  max_data_lengths = max(comm.alltoall(len(data)))
   data_list = list(data.items()) + [None] * max_data_lengths
   for index in range(max_data_lengths):
     print(f'gather2: {index=}, {datetime.now()=}')


### PR DESCRIPTION
This PR eliminates `mpi4py` communication issues when trying to send large amount of structure factors (>2GB) between ranks. Without this PR, attempting to simulate PSII data up to 3.0 Angstrom resolution using `kpp_utils/LY99_batch.py` results in an `OverflowError` or `SystemError`. After PR, the structure factor dictionaries are being sent value-by-value, which might slightly slow down the communication, but prevents said errors. Attempting to model extremely large datasets might still fail due to memory issues at a later stage if there is not enough memory to store everything on a single rank. The following table shows approximate execution status and time when simulating 100 PSII frames on 4 tasks on Perlmutter GPU node before and after the PR:

| Res. | Before  | After |
| -------------  | ------------- | -------------  |
| 3.5 Å | Terminates successfully after 7 min | Terminates successfully after 8 min |
| 3.0 Å | Raises `OverflowError` and hangs after 8 min | Terminates successfully after 9 min |
| 1.5 Å | Raises `SystemError` and hangs after 30 min | Terminates successfully after 30 min |

This table documents only a small subset of performed tests. For a PSII job finished on this branch, see directories `/global/cfs/cdirs/m3562/users/dtchon/p20231/common/ensemble1/SPREAD/SIM/0simulate` and `/pscratch/sd/d/dtchon/psii_sim/8707131/`.

Summary of individual changes:

- Modify file [kpp_utils/LY99_batch.py](https://github.com/ExaFEL/exafel_project/pull/14/files#diff-e979d5b0e49b364bf2b32d39a4c27df2907445a1c7c7f8a8a8c52c6e054fb2ea): Import new `bcast_large_dict`, broadcast `sfall_info` separately from `transmitted_info` and add it afterwards;
- Create file [kpp_utils/mp_utils.py](https://github.com/ExaFEL/exafel_project/pull/14/files#diff-d61f86080d16c9e5107513a96d8a6974aa143f130c2013ddc67f6168496acbd2): Implement `bcast_large_dict` and `collect_large_dict` to broadcast and gather+reconstruct dictionaries by passing their items one-by-one;
- Modify file [kpp_utils/psii_utils.py](https://github.com/ExaFEL/exafel_project/pull/14/files#diff-9aea2f9e81a81c30ea6fa7bc34158b9297672e7665596a70a7197fcaa7430183): Import new `collect_large_dict` and use it to gather all `sfall_channels` from individual ranks.